### PR TITLE
fix: Markdown table -- context-aware row split

### DIFF
--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -636,6 +636,47 @@ function renderBlockquote(content: string): string {
   return `<blockquote>${innerLines.map((l) => renderInline(l)).join("<br/>")}</blockquote>`;
 }
 
+const TABLE_CELL_GUARDS = new Set(["`", "$", '"', "'"]);
+
+/**
+ * Split a table row on `|`, skipping pipes inside code / math / quoted
+ * spans. A guard char pushes onto the stack when flanked like an opener
+ * (space/edge on the left, non-space on the right) and pops when it
+ * matches the top and is flanked like a closer. `|` splits only when
+ * the stack is empty; apostrophes inside words (`don't`) fail both
+ * flanking tests and don't enter the stack.
+ */
+function splitTableRow(row: string): string[] {
+  const cells: string[] = [];
+  const stack: string[] = [];
+  let current = "";
+
+  for (let i = 0; i < row.length; i++) {
+    const ch = row[i];
+
+    if (TABLE_CELL_GUARDS.has(ch)) {
+      const leftFree = i === 0 || /\s/.test(row[i - 1]);
+      const rightFree = i === row.length - 1 || /\s/.test(row[i + 1]);
+      const top = stack[stack.length - 1];
+
+      if (top === ch && !leftFree && rightFree) {
+        stack.pop();
+      } else if (top === undefined && leftFree && !rightFree) {
+        stack.push(ch);
+      }
+      current += ch;
+    } else if (ch === "|" && stack.length === 0) {
+      cells.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+
+  cells.push(current);
+  return cells;
+}
+
 /** Render table */
 function renderTable(content: string): string {
   const lines = content.split(/\r?\n/).filter((l) => l.trim());
@@ -644,8 +685,7 @@ function renderTable(content: string): string {
   }
 
   const readCells = (row: string) =>
-    row
-      .split("|")
+    splitTableRow(row)
       .map((cell) => cell.trim())
       .filter((cell, idx, arr) => {
         const isEdge = (idx === 0 || idx === arr.length - 1) && cell === "";

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -105,6 +105,125 @@ describe("markdown renderer", function () {
       assert.include(html, "<p>");
       assert.include(html, "<ul>");
     });
+
+    it("should keep | inside inline code as one cell", function () {
+      const md =
+        "| regex | note |\n| --- | --- |\n| `a|b` | alternation |";
+      const html = renderMarkdown(md);
+      assert.include(html, "<code>a|b</code>");
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 2);
+    });
+
+    it("should keep | inside inline math as one cell", function () {
+      const md =
+        "| expr | meaning |\n| --- | --- |\n| $x|y$ | divides |";
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 2);
+      assert.include(body, "divides");
+    });
+
+    it("should keep | inside double quotes as one cell", function () {
+      const md = '| word | value |\n| --- | --- |\n| pipe | "|" |';
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 2);
+      assert.include(body, "&quot;|&quot;");
+    });
+
+    it("should keep | inside single quotes as one cell", function () {
+      const md = "| word | value |\n| --- | --- |\n| pipe | '|' |";
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 2);
+      assert.include(body, "&#039;|&#039;");
+    });
+
+    it("should ignore word-internal apostrophes when splitting cells", function () {
+      const md =
+        "| word | meaning |\n| --- | --- |\n| don't | refuse |\n| won't | will not |";
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<tr>/g) || []).length, 2);
+      assert.equal((body.match(/<td>/g) || []).length, 4);
+    });
+
+    it("should handle mixed delimiter types across rows", function () {
+      const md =
+        '| kind | example |\n| --- | --- |\n| code | `a|b` |\n| quote | "c|d" |';
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 4);
+      assert.include(body, "<code>a|b</code>");
+      assert.include(body, "&quot;c|d&quot;");
+    });
+
+    it("should keep trailing | inside an unpaired opener", function () {
+      // Stack-based: an opener without a closer keeps the row inside
+      // its context, so pipes after it do not split further cells.
+      const md =
+        '| text | note |\n| --- | --- |\n| "open | unclosed |';
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 1);
+    });
+
+    it("should let outer backticks protect inner quoted |", function () {
+      const md =
+        '| code | note |\n| --- | --- |\n| `"a|b"` | quote inside code |';
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 2);
+      assert.include(body, "<code>&quot;a|b&quot;</code>");
+    });
+
+    it("should let outer double quotes protect inner apostrophe and |", function () {
+      const md =
+        `| phrase | note |\n| --- | --- |\n| "it's|fine" | apostrophe in quote |`;
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 2);
+      assert.include(body, "it&#039;s|fine");
+    });
+
+    it("should let outer single quotes protect inner double-quoted |", function () {
+      const md =
+        `| phrase | note |\n| --- | --- |\n| '"a|b"' | double inside single |`;
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 2);
+      assert.include(body, "&quot;a|b&quot;");
+    });
+
+    it("should protect math | alongside code | in the same row", function () {
+      const md =
+        "| expr | code |\n| --- | --- |\n| $a|b$ | `c|d` |";
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 2);
+      assert.include(body, "<code>c|d</code>");
+    });
+
+    it("should combine code and quoted | guards in one cell", function () {
+      const md =
+        '| kind | sample |\n| --- | --- |\n| mix | `a|b` and "c|d" |';
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 2);
+      assert.include(body, "<code>a|b</code>");
+      assert.include(body, "&quot;c|d&quot;");
+    });
+
+    it("should honor the outermost guard with triple nesting", function () {
+      const md =
+        '| phrase | note |\n| --- | --- |\n| "`$x|y$`" | triple nesting |';
+      const html = renderMarkdown(md);
+      const body = html.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] || "";
+      assert.equal((body.match(/<td>/g) || []).length, 2);
+      // The | inside the outermost "..." pair must not split the row
+      assert.include(body, "triple nesting");
+    });
   });
 
   describe("renderMarkdownForNote", function () {


### PR DESCRIPTION
Make the parsing of Markdown table more context-aware. Use a stack to maintain the context related to 
```
`$"'
```