### PR TITLE
Release 2.3.4 macOS connectivity fixes

### DIFF
--- a/.github/release_notes.md
+++ b/.github/release_notes.md
@@ -1,13 +1,9 @@
 ## What's Changed
 
-- **Windows npm warning handling**: hidden PowerShell commands now return the real native process exit code, so `npm warn using --force` from `npm install -g --force @openai/codex@latest` is no longer treated as a failed install when npm succeeds.
-- **Live Settings console sync**: OAuth environment updates started from the popup now stream progress into the Settings console and keep `oauthSetupLog` updated while the task is running.
-- **Cleaner update prompt controls**: the OAuth update prompt now has a top-right minimize control, and after completion the action area is replaced with a single OK button that closes the prompt.
-- **Clearer failure feedback**: if an OAuth environment update really fails, the prompt now shows the last failed step instead of only a generic message.
+- **macOS Apple Silicon Node/npm detection**: OAuth CLI environment checks now respect the user's login shell PATH before falling back to built-in paths, and macOS fallback lookup now prefers `/opt/homebrew/bin` before legacy `/usr/local/bin`, preventing stale x64 Node installs from being selected on Apple Silicon Macs. Fixes #26, thanks @werifu for identifying the root cause.
+- **Environment diagnostics**: OAuth environment logs now include `nodeArch`, making it easier to confirm whether the selected Node runtime is `arm64` or `x64`.
 
 ## 更新内容
 
-- **Windows npm warning 处理**：隐藏 PowerShell 命令现在会返回真实的原生命令退出码，因此 `npm install -g --force @openai/codex@latest` 成功时产生的 `npm warn using --force` 不会再被误判为安装失败。
-- **Settings 控制台实时同步**：从弹窗启动的 OAuth 环境更新现在会把进度实时写入 Settings 控制台，并在任务执行过程中持续更新 `oauthSetupLog`。
-- **更清晰的更新弹窗控制**：OAuth 更新弹窗新增右上角最小化按钮；更新完成后，操作区会替换为单个“确定”按钮，点击后关闭弹窗。
-- **更明确的失败反馈**：如果 OAuth 环境更新确实失败，弹窗会显示最后一个失败步骤，而不再只显示通用失败提示。
+- **macOS Apple Silicon Node/npm 检测**：OAuth CLI 环境检查现在会先尊重用户登录 shell 的 PATH，再使用内置路径兜底；macOS 兜底查找也会优先使用 `/opt/homebrew/bin`，再使用旧的 `/usr/local/bin`，避免 Apple Silicon Mac 误选残留的 x64 Node。修复 #26，感谢 @werifu 定位根因。
+- **环境诊断信息**：OAuth 环境日志现在会记录 `nodeArch`，便于确认当前选中的 Node 运行时是 `arm64` 还是 `x64`。

--- a/.github/release_notes.md
+++ b/.github/release_notes.md
@@ -1,9 +1,11 @@
 ## What's Changed
 
 - **macOS Apple Silicon Node/npm detection**: OAuth CLI environment checks now respect the user's login shell PATH before falling back to built-in paths, and macOS fallback lookup now prefers `/opt/homebrew/bin` before legacy `/usr/local/bin`, preventing stale x64 Node installs from being selected on Apple Silicon Macs. Fixes #26, thanks @werifu for identifying the root cause.
+- **macOS system proxy support**: AIdea now detects macOS system HTTP/HTTPS/SOCKS proxy settings with `scutil --proxy` and applies them to Zotero's Gecko networking and CLI subprocess environment, improving OAuth and model connectivity behind local proxy tools. Thanks @werifu for the contribution in #27.
 - **Environment diagnostics**: OAuth environment logs now include `nodeArch`, making it easier to confirm whether the selected Node runtime is `arm64` or `x64`.
 
 ## 更新内容
 
 - **macOS Apple Silicon Node/npm 检测**：OAuth CLI 环境检查现在会先尊重用户登录 shell 的 PATH，再使用内置路径兜底；macOS 兜底查找也会优先使用 `/opt/homebrew/bin`，再使用旧的 `/usr/local/bin`，避免 Apple Silicon Mac 误选残留的 x64 Node。修复 #26，感谢 @werifu 定位根因。
+- **macOS 系统代理支持**：AIdea 现在会通过 `scutil --proxy` 检测 macOS 系统 HTTP/HTTPS/SOCKS 代理，并同步应用到 Zotero 的 Gecko 网络层和 CLI 子进程环境，改善本地代理工具场景下的 OAuth 与模型连接。感谢 @werifu 在 #27 中贡献修复。
 - **环境诊断信息**：OAuth 环境日志现在会记录 `nodeArch`，便于确认当前选中的 Node 运行时是 `arm64` 还是 `x64`。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aidea-for-zotero",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aidea-for-zotero",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "katex": "^0.16.45",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aidea-for-zotero",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aidea-for-zotero",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "katex": "^0.16.45",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aidea-for-zotero",
   "type": "module",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "AIdea: Free AI assistant for Zotero — Chat with AI directly in Zotero's side panel",
   "config": {
     "addonName": "AIdea",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aidea-for-zotero",
   "type": "module",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "AIdea: Free AI assistant for Zotero — Chat with AI directly in Zotero's side panel",
   "config": {
     "addonName": "AIdea",

--- a/src/utils/oauthCli.ts
+++ b/src/utils/oauthCli.ts
@@ -142,6 +142,7 @@ type NpmEnvironmentState = {
   nodePath: string | null;
   npmPath: string | null;
   nodeVersion: string;
+  nodeArch: string;
   npmReportedVersion: string;
   npmPackageVersion: string;
   latestNpmVersion: string;
@@ -751,11 +752,25 @@ function getCommonExecutableDirs(platform: SupportedPlatform): string[] {
     ).filter(isDirectoryPath);
   }
 
+  if (platform === "macos") {
+    return dedupePathEntries(
+      [
+        // Apple Silicon Homebrew defaults to /opt/homebrew. Keep it ahead of
+        // legacy Intel /usr/local so a stale x64 node cannot win fallback lookup.
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        home ? joinPath(home, ".local", "bin") : "",
+        home ? joinPath(home, ".npm-global", "bin") : "",
+      ],
+      platform,
+    ).filter(isDirectoryPath);
+  }
+
   return dedupePathEntries(
     [
       "/usr/local/bin",
       "/usr/bin",
-      "/opt/homebrew/bin",
       home ? joinPath(home, ".local", "bin") : "",
       home ? joinPath(home, ".npm-global", "bin") : "",
     ],
@@ -823,15 +838,9 @@ async function locateExecutableViaShell(
   const platform = currentPlatform();
   const trimmed = String(baseName || "").trim();
   if (!trimmed) return null;
-  const command =
-    platform === "windows"
-      ? `where.exe ${trimmed}`
-      : `command -v ${escapeShellArg(trimmed)} 2>/dev/null || which ${escapeShellArg(trimmed)} 2>/dev/null`;
-  try {
-    const result = await runShellCommand(command, { hidden: true });
-    if (result.code !== 0) return null;
 
-    const candidates = String([result.stdout, result.stderr].join("\n"))
+  const chooseCandidate = (rawOutput: string): string | null => {
+    const candidates = rawOutput
       .split(/\r?\n/g)
       .map((line) => line.trim())
       .filter((line) => Boolean(line) && pathExists(line));
@@ -854,10 +863,41 @@ async function locateExecutableViaShell(
       }
     }
 
+    return chosen || null;
+  };
+
+  const runLocator = async (command: string): Promise<string | null> => {
+    const result = await runShellCommand(command, { hidden: true });
+    if (result.code !== 0) return null;
+
+    const chosen = chooseCandidate(
+      String([result.stdout, result.stderr].join("\n")),
+    );
     if (!chosen) return null;
     const dir = initLocalFile(chosen)?.parent?.path || "";
     if (dir) prependProcessPathEntries([dir]);
     return chosen;
+  };
+
+  try {
+    if (platform === "windows") {
+      return await runLocator(`where.exe ${trimmed}`);
+    }
+
+    const unixLocator = `command -v ${escapeShellArg(trimmed)} 2>/dev/null || which ${escapeShellArg(trimmed)} 2>/dev/null`;
+    const shellCandidates = dedupePathEntries(
+      [getEnv("SHELL"), platform === "macos" ? "/bin/zsh" : "", "/bin/bash"],
+      platform,
+    ).filter((shellPath) => Boolean(shellPath) && pathExists(shellPath));
+
+    for (const shellPath of shellCandidates) {
+      const found = await runLocator(
+        `${escapeShellArg(shellPath)} -lc ${escapeShellArg(unixLocator)}`,
+      );
+      if (found) return found;
+    }
+
+    return await runLocator(unixLocator);
   } catch {
     return null;
   }
@@ -1016,17 +1056,25 @@ async function inspectNpmEnvironment(
     prependProcessPathEntries([preferredBin]);
   }
 
-  prependProcessPathEntries(getCommonExecutableDirs(platform));
-
   const nodePath =
     (await locateExecutableViaShell("node")) || resolveExecutablePath("node");
   const npmPath =
     (await locateExecutableViaShell("npm")) || resolveExecutablePath("npm");
 
   let nodeVersion = "";
+  let nodeArch = "";
   if (nodePath) {
     const nodeResult = await runExecutableCommand(nodePath, ["--version"]);
     nodeVersion = normalizeVersionText(nodeResult.output);
+    const archResult = await runExecutableCommand(nodePath, [
+      "-p",
+      "process.arch",
+    ]);
+    nodeArch =
+      String(archResult.output || "")
+        .split(/\r?\n/g)
+        .map((line) => line.trim())
+        .find(Boolean) || "";
   }
 
   let npmReportedVersion = "";
@@ -1084,6 +1132,7 @@ async function inspectNpmEnvironment(
     nodePath,
     npmPath,
     nodeVersion,
+    nodeArch,
     npmReportedVersion,
     npmPackageVersion,
     latestNpmVersion,
@@ -2537,8 +2586,8 @@ async function getNpmGlobalRootCandidates(): Promise<string[]> {
     const appData = getEnv("APPDATA") || joinPath(home, "AppData", "Roaming");
     roots.add(joinPath(appData, "npm", "node_modules"));
   } else {
-    roots.add("/usr/local/lib/node_modules");
     roots.add("/opt/homebrew/lib/node_modules");
+    roots.add("/usr/local/lib/node_modules");
     if (home) {
       roots.add(joinPath(home, ".npm-global", "lib", "node_modules"));
     }
@@ -3389,6 +3438,7 @@ export async function autoConfigureEnvironment(params?: {
       `platform: ${state.platform}`,
       `nodePath: ${state.nodePath || "-"}`,
       `nodeVersion: ${state.nodeVersion || "-"}`,
+      `nodeArch: ${state.nodeArch || "-"}`,
       `npmPath: ${state.npmPath || "-"}`,
       `npmReportedVersion: ${state.npmReportedVersion || "-"}`,
       `npmPackageVersion: ${state.npmPackageVersion || "-"}`,


### PR DESCRIPTION
## Summary

- Bring the macOS OAuth CLI Node/npm fallback fix onto the current master line after PR #27.
- Bump package metadata to 2.3.4.
- Update release notes to include both Apple Silicon Node/npm detection and macOS system proxy support.

## Verification

- `node node_modules\tsx\dist\cli.cjs node_modules\mocha\bin\mocha.js --timeout 10000 test/oauthCliEnvironment.test.ts`
- `node node_modules\typescript\bin\tsc --noEmit`
- `node node_modules\prettier\bin\prettier.cjs --check .github/release_notes.md package.json package-lock.json src/hooks.ts src/utils/oauthCli.ts test/oauthCliEnvironment.test.ts`
- `node node_modules\zotero-plugin-scaffold\bin\zotero-plugin.mjs build`

## Notes

- macOS end-to-end smoke testing was not performed because no macOS system is available.
- `npm run build` could not find the `zotero-plugin` shim in this local `node_modules/.bin`, so the equivalent scaffold CLI entrypoint was used directly.