### PR TITLE
Add siyuanj to contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+# Contributors
+
+- [siyuanj](https://github.com/siyuanj)


### PR DESCRIPTION
Adds my GitHub handle to CONTRIBUTORS.md, as suggested in #36, so GitHub can associate the corresponding-author profile contribution through the commit history.