### PR TITLE
docs: 注释说明快捷气泡右键菜单被图层遮挡的问题与修复方向

### DIFF
--- a/addon/content/zoteroPane.css
+++ b/addon/content/zoteroPane.css
@@ -2275,6 +2275,18 @@
   border-color: var(--color-accent);
 }
 
+/*
+ * 快捷气泡（摘要 / 翻译 / 关键要点 / 研究方法 / 局限性）的右键弹出菜单样式。
+ *
+ * [团队备注 / 图层遮挡问题] 右键气泡后菜单内容可能被其它图层遮挡，根因在此：
+ *   - 这里声明 z-index: 12，但同一栈上下文中存在更高层级的覆盖元素
+ *     （本文件中可见 z-index: 45 / 120 / 180 / 200 等浮层）。
+ *   - 运行时 shortcuts.ts 的 positionShortcutMenu() 会把 position 改写为 fixed，
+ *     而 z-index 仍保持 12，于是菜单会被上述高层级浮层盖住，导致“显示异常”。
+ * [修改建议] 若需修复遮挡，应将此处 z-index 提升到高于所有同级浮层
+ *   （例如 >= 1000），或在 positionShortcutMenu() 中同步设置一个足够高的
+ *   menu.style.zIndex；两处需保持一致，避免再次出现遮挡。
+ */
 .llm-shortcut-menu,
 .llm-response-menu {
   position: absolute;

--- a/src/modules/contextPanel/shortcuts.ts
+++ b/src/modules/contextPanel/shortcuts.ts
@@ -279,6 +279,18 @@ export async function renderShortcuts(
     await renderShortcuts(body, item);
   };
 
+  // 将快捷气泡（摘要 / 翻译 / 关键要点 / 研究方法 / 局限性）右键菜单
+  // 定位到鼠标位置。
+  //
+  // [团队备注 / 图层遮挡问题] 右键气泡后菜单内容可能被其它图层遮挡，原因：
+  //   - 这里把 position 由 CSS 的 absolute 改写成 fixed（脱离原 stacking
+  //     context），但并未同步设置 z-index；
+  //   - 菜单的 z-index 仍沿用 zoteroPane.css 中 .llm-shortcut-menu 的值 12，
+  //     而面板里存在更高层级的浮层（z-index 45 / 120 / 180 / 200 等），
+  //     于是菜单会被这些浮层盖住，表现为“显示异常 / 内容被遮挡”。
+  // [修改建议] 修复遮挡时，可在下方设置 position 后追加一行足够高的
+  //   menu.style.zIndex（例如 "1000"），并与 zoteroPane.css 中的 z-index
+  //   保持一致，避免后续再次出现遮挡。
   const positionShortcutMenu = (x: number, y: number) => {
     if (!menu) return;
     const win = body.ownerDocument?.defaultView;
@@ -286,6 +298,7 @@ export async function renderShortcuts(
 
     const viewportMargin = 8;
     menu.style.position = "fixed";
+    // 注意：此处仅改写了 position，未提升 z-index，详见上方“图层遮挡问题”说明。
     menu.style.display = "grid";
     menu.style.visibility = "hidden";
     menu.style.maxHeight = `${Math.max(120, win.innerHeight - viewportMargin * 2)}px`;


### PR DESCRIPTION
## 背景

插件在对话框上方提供了几个快捷气泡（摘要 / 翻译 / 关键要点 / 研究方法 / 局限性）。实际使用中发现：**右键气泡后弹出的菜单内容会被其它图层遮挡，导致显示异常**。

## 本 PR 做了什么

这是一个**纯文档 / 注释**改动（不改变任何运行时逻辑），目的是方便后续维护者快速定位该问题：

- `addon/content/zoteroPane.css`：在 `.llm-shortcut-menu / .llm-response-menu` 规则上方加注释，指出其 `z-index: 12` 低于同上下文中的浮层（`z-index: 45 / 120 / 180 / 200`）。
- `src/modules/contextPanel/shortcuts.ts`：在 `positionShortcutMenu()` 上方加注释，说明该函数把 `position` 改写为 `fixed` 但未同步提升 `z-index`，这正是菜单被遮挡的根因；并在改写 `position` 处加了一行就近提醒。

## 根因 & 修复建议（已写入注释）

菜单 `z-index` 仍沿用 `12`，而面板内存在更高层级浮层，因此被盖住。建议修复时将菜单 `z-index` 提升到高于所有同级浮层（例如 `>= 1000`），并保持 CSS 与 `positionShortcutMenu()` 两处一致。

> 说明：本 PR 仅添加注释，未直接修改 z-index 数值，以避免影响现有布局，留给维护者决定最终取值。