### PR TITLE
fix: normalize missing Zotero items

### DIFF
--- a/src/modules/authorProfiles/cache.ts
+++ b/src/modules/authorProfiles/cache.ts
@@ -1,4 +1,5 @@
 import { renderMarkdownForNote } from "../../utils/markdown";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import { getAllAuthorProfileNoteTitles, getAuthorProfileCopy } from "./i18n";
 import type { AuthorProfileResult } from "./types";
 import { NOTE_MARKER } from "./utils";
@@ -27,7 +28,7 @@ async function getChildNotes(parentItem: Zotero.Item): Promise<Zotero.Item[]> {
         const id = Number(rawId);
         if (!Number.isFinite(id) || id <= 0 || seen.has(id)) continue;
         seen.add(id);
-        const note = Zotero.Items.get(id) || null;
+        const note = getZoteroItem(id);
         if (note?.isNote?.()) out.push(note);
       }
     }

--- a/src/modules/authorProfiles/menu.ts
+++ b/src/modules/authorProfiles/menu.ts
@@ -1,4 +1,5 @@
 import { config } from "../../../package.json";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import {
   isAuthorProfileRunInProgress,
   runAuthorProfileGeneration,
@@ -15,7 +16,7 @@ function resolveProcessableItem(item: Zotero.Item): Zotero.Item | null {
   if (!item) return null;
   if (item.isRegularItem?.()) return item;
   if (item.isAttachment?.() && item.parentID) {
-    return Zotero.Items.get(item.parentID) || null;
+    return getZoteroItem(item.parentID);
   }
   return null;
 }

--- a/src/modules/authorProfiles/resolver.ts
+++ b/src/modules/authorProfiles/resolver.ts
@@ -7,6 +7,7 @@ import type {
   PaperMetadata,
   SourceResult,
 } from "./types";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import {
   fetchCrossrefAuthors,
   fetchOpenAlexAuthorMetrics,
@@ -108,7 +109,7 @@ function getPdfAttachments(item: Zotero.Item): Zotero.Item[] {
   }
   try {
     for (const id of item.getAttachments?.() || []) {
-      pushIfPdf(Zotero.Items.get(id) || null);
+      pushIfPdf(getZoteroItem(id));
     }
   } catch {
     /* no attachments */

--- a/src/modules/contextPanel/chat.ts
+++ b/src/modules/contextPanel/chat.ts
@@ -1,4 +1,5 @@
 import { renderMarkdown, renderMarkdownForNote } from "../../utils/markdown";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import {
   findAssistantBubbleByMessageId,
   patchStreamingBubble,
@@ -1177,7 +1178,7 @@ async function buildCombinedContextForRequest(params: {
     // Rebuild from the stored ID instead of re-resolving from the current tab.
     params.setStatusSafely(getPanelI18n().rebuildingDocumentContext, "sending");
     try {
-      const ctxItem = Zotero.Items.get(pool.basePdfItemId);
+      const ctxItem = getZoteroItem(pool.basePdfItemId);
       if (ctxItem) {
         await ensurePDFTextCached(ctxItem);
         const cached = pdfTextCache.get(ctxItem.id);
@@ -1245,7 +1246,7 @@ async function buildCombinedContextForRequest(params: {
       pool.basePdfItemId = ctxItem.id;
       try {
         const parentItem = ctxItem.parentID
-          ? Zotero.Items.get(ctxItem.parentID)
+          ? getZoteroItem(ctxItem.parentID)
           : null;
         pool.basePdfTitle =
           (parentItem ? parentItem.getField("title") : "") ||
@@ -1345,7 +1346,7 @@ function buildContextRefsSnapshot(
     // Find the parent item ID from the PDF attachment.
     let parentItemId = pool.basePdfItemId;
     try {
-      const attachment = Zotero.Items.get(pool.basePdfItemId);
+      const attachment = getZoteroItem(pool.basePdfItemId);
       if (attachment?.parentID) {
         parentItemId = attachment.parentID;
       }

--- a/src/modules/contextPanel/contextResolution.ts
+++ b/src/modules/contextPanel/contextResolution.ts
@@ -4,6 +4,7 @@ import {
   isLikelyCorruptedSelectedText,
   setStatus,
 } from "./textUtils";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import {
   normalizePaperContextRefs,
   normalizeSelectedTextSource,
@@ -213,8 +214,8 @@ function getActiveReaderAttachmentFromTabs(
   const data = activeTab.data || {};
   const candidateIDs = collectCandidateItemIDsFromObject(data);
   for (const itemId of candidateIDs) {
-    const item = Zotero.Items.get(itemId);
-    if (isSupported(item)) return item;
+    const item = getZoteroItem(itemId);
+    if (item && isSupported(item)) return item;
   }
 
   // Fallback: map selected tab id to reader instance if available.
@@ -225,8 +226,8 @@ function getActiveReaderAttachmentFromTabs(
   ).Reader?.getByTabID?.(selectedId);
   const readerItemId = parseItemID(reader?._item?.id ?? reader?.itemID);
   if (readerItemId !== null) {
-    const readerItem = Zotero.Items.get(readerItemId);
-    if (isSupported(readerItem)) return readerItem;
+    const readerItem = getZoteroItem(readerItemId);
+    if (readerItem && isSupported(readerItem)) return readerItem;
   }
 
   return null;
@@ -264,7 +265,7 @@ function getFirstPdfChildAttachment(
   if (!item || item.isAttachment()) return null;
   const attachments = item.getAttachments();
   for (const attachmentId of attachments) {
-    const attachment = Zotero.Items.get(attachmentId);
+    const attachment = getZoteroItem(attachmentId);
     if (isSupportedContextAttachment(attachment)) {
       return attachment;
     }
@@ -356,7 +357,7 @@ export function getActiveReaderSelectionText(
   //    the cache entry is automatically cleared, preventing stale results.
   const itemId = reader?._item?.id || reader?.itemID;
   if (typeof itemId === "number") {
-    const readerItem = Zotero.Items.get(itemId) || null;
+    const readerItem = getZoteroItem(itemId);
     const readerKeys = getItemSelectionCacheKeys(readerItem);
     for (const key of readerKeys) {
       const fromCache = recentReaderSelectionCache.get(key) || "";

--- a/src/modules/contextPanel/documentContext.ts
+++ b/src/modules/contextPanel/documentContext.ts
@@ -1,4 +1,5 @@
 import { cacheExtractedDocumentText, ensurePDFTextCached } from "./pdfContext";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import {
   epubTextRetryAfterByItem,
   pdfTextCache,
@@ -78,7 +79,7 @@ export function resolveReaderDocument(
   const attachmentIDs = item.getAttachments();
   const documents: ReaderDocument[] = [];
   for (const id of attachmentIDs) {
-    const document = asReaderDocument(Zotero.Items.get(id) || null);
+    const document = asReaderDocument(getZoteroItem(id));
     if (document) documents.push(document);
   }
   if (!documents.length) return null;
@@ -170,7 +171,7 @@ function getDocumentTitle(item: Zotero.Item): string {
   try {
     const parent =
       item.isAttachment?.() && item.parentID
-        ? Zotero.Items.get(item.parentID)
+        ? getZoteroItem(item.parentID)
         : null;
     return String(
       parent?.getField?.("title") || item.getField?.("title") || "",

--- a/src/modules/contextPanel/index.ts
+++ b/src/modules/contextPanel/index.ts
@@ -23,6 +23,7 @@
 
 import { getLocaleID } from "../../utils/locale";
 import { renderMarkdown } from "../../utils/markdown";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import { config, GLOBAL_CONVERSATION_KEY_BASE, PANE_ID } from "./constants";
 import type { Message } from "./types";
 import {
@@ -699,7 +700,7 @@ export function registerReaderSelectionTracking() {
     })();
     const itemId = event.reader?._item?.id || event.reader?.itemID;
     if (typeof itemId !== "number") return;
-    const item = Zotero.Items.get(itemId) || null;
+    const item = getZoteroItem(itemId);
     const cacheKeys = getItemSelectionCacheKeys(item);
     const keys = cacheKeys.length ? cacheKeys : [itemId];
     const isPopupOptionEnabled = (key: string): boolean => {
@@ -766,9 +767,7 @@ export function registerReaderSelectionTracking() {
         };
       };
       if (item?.attachmentContentType === EPUB_CONTENT_TYPE) {
-        const parent = item.parentID
-          ? Zotero.Items.get(item.parentID) || null
-          : null;
+        const parent = item.parentID ? getZoteroItem(item.parentID) : null;
         const title = sanitizeText(
           parent?.getField?.("title") ||
             item.getField?.("title") ||

--- a/src/modules/contextPanel/notes.ts
+++ b/src/modules/contextPanel/notes.ts
@@ -1,4 +1,5 @@
 import { renderMarkdownForNote } from "../../utils/markdown";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import {
   sanitizeText,
   escapeNoteHtml,
@@ -15,7 +16,7 @@ import { getPanelLang, type PanelLang } from "./i18n";
 
 function resolveParentItemForNote(item: Zotero.Item): Zotero.Item | null {
   if (item.isAttachment() && item.parentID) {
-    const parent = Zotero.Items.get(item.parentID) || null;
+    const parent = getZoteroItem(item.parentID);
     if (parent && parent.isRegularItem()) return parent;
     return null;
   }
@@ -350,7 +351,7 @@ async function findSelectionTranslationNote(
   }
 
   for (const noteId of noteIds) {
-    const note = Zotero.Items.get(noteId) || null;
+    const note = getZoteroItem(noteId);
     if (isSelectionTranslationNote(note)) return note;
   }
 

--- a/src/modules/contextPanel/paperAttribution.ts
+++ b/src/modules/contextPanel/paperAttribution.ts
@@ -1,4 +1,5 @@
 import type { PaperContextRef } from "./types";
+import { getZoteroItem as getZoteroItemById } from "../../utils/zoteroItems";
 
 function normalizeText(value: unknown): string {
   if (typeof value !== "string") return "";
@@ -26,7 +27,7 @@ function getZoteroItem(itemId: number): Zotero.Item | null {
     ) {
       return null;
     }
-    return Zotero.Items.get(itemId) || null;
+    return getZoteroItemById(itemId);
   } catch {
     return null;
   }

--- a/src/modules/contextPanel/paperContext.ts
+++ b/src/modules/contextPanel/paperContext.ts
@@ -3,6 +3,7 @@ import {
   SUPPLEMENTAL_PAPER_CONTEXT_MAX_LENGTH,
   SUPPLEMENTAL_PAPER_CONTEXT_TOTAL_MAX_LENGTH,
 } from "./constants";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import { ensurePDFTextCached, buildContext } from "./pdfContext";
 import { pdfTextCache } from "./state";
 import type { PaperContextRef } from "./types";
@@ -18,7 +19,7 @@ function getFirstPdfChildAttachment(
   if (!item || item.isAttachment()) return null;
   const attachments = item.getAttachments();
   for (const attachmentId of attachments) {
-    const attachment = Zotero.Items.get(attachmentId);
+    const attachment = getZoteroItem(attachmentId);
     if (
       attachment &&
       attachment.isAttachment() &&
@@ -31,7 +32,7 @@ function getFirstPdfChildAttachment(
 }
 
 function resolveContextItem(ref: PaperContextRef): Zotero.Item | null {
-  const direct = Zotero.Items.get(ref.contextItemId);
+  const direct = getZoteroItem(ref.contextItemId);
   if (
     direct &&
     direct.isAttachment() &&
@@ -39,7 +40,7 @@ function resolveContextItem(ref: PaperContextRef): Zotero.Item | null {
   ) {
     return direct;
   }
-  const item = Zotero.Items.get(ref.itemId);
+  const item = getZoteroItem(ref.itemId);
   return getFirstPdfChildAttachment(item);
 }
 

--- a/src/modules/contextPanel/paperSearch.ts
+++ b/src/modules/contextPanel/paperSearch.ts
@@ -1,4 +1,5 @@
 import type { PaperContextRef } from "./types";
+import { getZoteroItem } from "../../utils/zoteroItems";
 
 export type PaperSearchAttachmentCandidate = {
   contextItemId: number;
@@ -102,8 +103,8 @@ function getPdfChildAttachments(item: Zotero.Item): Zotero.Item[] {
   if (!item?.isRegularItem?.()) return out;
   const attachments = item.getAttachments();
   for (const attachmentId of attachments) {
-    const attachment = Zotero.Items.get(attachmentId);
-    if (isPdfAttachment(attachment)) {
+    const attachment = getZoteroItem(attachmentId);
+    if (attachment && isPdfAttachment(attachment)) {
       out.push(attachment);
     }
   }
@@ -332,10 +333,7 @@ export async function searchPaperCandidates(
 
   for (const item of items) {
     if (isPdfAttachment(item)) {
-      if (
-        (item as Zotero.Item).parentID ||
-        (excludeId && item.id === excludeId)
-      ) {
+      if (item.parentID || (excludeId && item.id === excludeId)) {
         continue;
       }
       const standalone = buildStandaloneAttachmentCandidate(item);

--- a/src/modules/contextPanel/pdfContext.ts
+++ b/src/modules/contextPanel/pdfContext.ts
@@ -1,4 +1,5 @@
 import { callEmbeddings } from "../../utils/llmClient";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import {
   CHUNK_TARGET_LENGTH,
   CHUNK_OVERLAP,
@@ -45,7 +46,7 @@ async function cachePDFText(item: Zotero.Item) {
     let pdfText = "";
     const mainItem =
       item.isAttachment() && item.parentID
-        ? Zotero.Items.get(item.parentID)
+        ? getZoteroItem(item.parentID)
         : null;
 
     const title = mainItem?.getField("title") || item.getField("title") || "";

--- a/src/modules/contextPanel/prefHelpers.ts
+++ b/src/modules/contextPanel/prefHelpers.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_TEMPERATURE,
   MAX_ALLOWED_TOKENS,
 } from "../../utils/llmDefaults";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import {
   normalizeTemperature,
   normalizeMaxTokens,
@@ -765,7 +766,7 @@ export function getTrackedAssistantNoteForParent(
   }
   let note: Zotero.Item | null;
   try {
-    note = Zotero.Items.get(noteId) || null;
+    note = getZoteroItem(noteId);
   } catch {
     ztoolkit.log(`LLM: Failed to get note item ${noteId}`);
     removeAssistantNoteMapEntry(parentItemId);

--- a/src/modules/contextPanel/selectionTranslate.ts
+++ b/src/modules/contextPanel/selectionTranslate.ts
@@ -1,4 +1,5 @@
 import { callLLM, callLLMStream } from "../../utils/llmClient";
+import { getZoteroItem } from "../../utils/zoteroItems";
 import {
   loadSelectionTranslateColdStartCache,
   saveSelectionTranslateColdStartCache,
@@ -258,7 +259,7 @@ function getDocumentMetadata(
 } {
   const parent =
     documentItem.isAttachment?.() && documentItem.parentID
-      ? Zotero.Items.get(documentItem.parentID)
+      ? getZoteroItem(documentItem.parentID)
       : null;
   const title =
     parent?.getField?.("title") ||

--- a/src/modules/contextPanel/setupHandlers/controllers/composeContextController.ts
+++ b/src/modules/contextPanel/setupHandlers/controllers/composeContextController.ts
@@ -2,6 +2,7 @@ import { normalizePaperContextRefs } from "../../normalizers";
 import { sanitizeText } from "../../textUtils";
 import { resolvePaperContextDisplayMetadata as resolvePaperContextDisplayMetadataShared } from "../../paperAttribution";
 import type { PaperContextRef } from "../../types";
+import { getZoteroItem as getZoteroItemById } from "../../../../utils/zoteroItems";
 
 export function normalizePaperContextEntries(
   value: unknown,
@@ -58,7 +59,7 @@ function getZoteroItem(itemId: number): Zotero.Item | null {
     ) {
       return null;
     }
-    return Zotero.Items.get(itemId) || null;
+    return getZoteroItemById(itemId);
   } catch {
     return null;
   }

--- a/src/modules/contextPanel/setupHandlers/controllers/fileIntakeController.ts
+++ b/src/modules/contextPanel/setupHandlers/controllers/fileIntakeController.ts
@@ -10,6 +10,7 @@ import {
   extractTextFromPdfPath,
   extractTextFromStoredFile,
 } from "../../../../utils/fileExtraction";
+import { getZoteroItem } from "../../../../utils/zoteroItems";
 import { getPanelI18n } from "../../i18n";
 
 type StatusLevel = "ready" | "warning" | "error";
@@ -220,16 +221,16 @@ export async function resolveZoteroItemFiles(
   const seenAttachmentIds = new Set<number>();
   for (const id of ids) {
     try {
-      const zoteroItem = Zotero.Items.get(id);
+      const zoteroItem = getZoteroItem(id);
       if (!zoteroItem) continue;
       const candidateAttachments: Zotero.Item[] = [];
       if (isReadableLocalAttachment(zoteroItem)) {
         candidateAttachments.push(zoteroItem);
-      } else if ((zoteroItem as Zotero.Item).isRegularItem()) {
+      } else if (zoteroItem.isRegularItem()) {
         const attachmentIds = zoteroItem.getAttachments();
         for (const attId of attachmentIds) {
-          const att = Zotero.Items.get(attId);
-          if (isReadableLocalAttachment(att)) {
+          const att = getZoteroItem(attId);
+          if (att && isReadableLocalAttachment(att)) {
             candidateAttachments.push(att);
           }
         }

--- a/src/utils/attachmentRefStore.ts
+++ b/src/utils/attachmentRefStore.ts
@@ -4,6 +4,7 @@ import {
   removeAttachmentFile,
 } from "../modules/contextPanel/attachmentStorage";
 import { fileUrlToPath } from "./pathFileUrl";
+import { getZoteroItem } from "./zoteroItems";
 
 export type AttachmentRefOwnerType = "conversation" | "note";
 
@@ -152,7 +153,7 @@ export async function reconcileNoteAttachmentRefsFromNoteContent(): Promise<void
     if (!Number.isFinite(ownerId) || ownerId <= 0) continue;
     let note: Zotero.Item | null;
     try {
-      note = Zotero.Items.get(ownerId) || null;
+      note = getZoteroItem(ownerId);
     } catch (_err) {
       note = null;
     }

--- a/src/utils/zoteroItems.ts
+++ b/src/utils/zoteroItems.ts
@@ -1,0 +1,10 @@
+/**
+ * Resolve one Zotero item while hiding Zotero's `false` sentinel from callers.
+ *
+ * Zotero returns `false` when an item ID cannot be resolved. Normalizing that
+ * value at this boundary keeps the rest of the application on the conventional
+ * `Item | null` contract.
+ */
+export function getZoteroItem(itemID: number | string): Zotero.Item | null {
+  return Zotero.Items.get(itemID) || null;
+}

--- a/test/zoteroItems.test.ts
+++ b/test/zoteroItems.test.ts
@@ -1,0 +1,31 @@
+import { assert } from "chai";
+import { getZoteroItem } from "../src/utils/zoteroItems";
+
+const originalZotero = (globalThis as Record<string, unknown>).Zotero;
+
+describe("zoteroItems", function () {
+  afterEach(function () {
+    (globalThis as Record<string, unknown>).Zotero = originalZotero;
+  });
+
+  it("returns an existing Zotero item unchanged", function () {
+    const item = { id: 42 } as Zotero.Item;
+    (globalThis as Record<string, unknown>).Zotero = {
+      Items: {
+        get: () => item,
+      },
+    };
+
+    assert.strictEqual(getZoteroItem(42), item);
+  });
+
+  it("normalizes Zotero's missing-item false sentinel to null", function () {
+    (globalThis as Record<string, unknown>).Zotero = {
+      Items: {
+        get: () => false,
+      },
+    };
+
+    assert.isNull(getZoteroItem(404));
+  });
+});


### PR DESCRIPTION
## What changed

- add a shared `getZoteroItem()` boundary that converts Zotero's missing-item `false` sentinel to `null`
- route all scalar `Zotero.Items.get()` calls through the shared boundary
- remove redundant item assertions and add regression coverage for existing and missing items

## Why

`zotero-types` 4.1.3 corrected `Zotero.Items.get(id)` to return `Zotero.Item | false`. The stricter signature exposed unsafe assumptions in multiple context-panel paths and caused PR #64 to fail TypeScript compilation.

## Impact

This is a type-safety and missing-item compatibility fix. Existing items are returned unchanged; deleted or unresolved item IDs are handled as `null` consistently.

## Validation

Validated locally with the exact dependency versions from PR #64:

- `npm run test:unit` — 408 passing
- `npm run build` — passed
- `npm run lint:check` — passed

Unblocks #64.