### PR TITLE
release: prepare v3.3.1

### DIFF
--- a/.github/release_notes.md
+++ b/.github/release_notes.md
@@ -1,23 +1,21 @@
 ## What's Changed
 
-- **EPUB selection translation and automatic format detection**: AIdea now supports translating selected text directly in Zotero's EPUB reader. The existing selection-translation action automatically detects the active PDF or EPUB, with no new setting or manual format switch required. Thanks @senlinyy for the contribution in #62.
-- **More accurate attachment selection**: when a Zotero item contains both PDF and EPUB attachments, AIdea follows the attachment currently open in the reader instead of relying on attachment order.
-- **Translation remains available without extracted context**: selection translation can continue when extracted document text is unavailable for either PDF or EPUB. Temporarily empty EPUB full-text caches are retried automatically.
-- **Existing PDF workflow preserved**: normal PDF selection translation and PDF side-panel document chat continue to work as before, with additional coverage for mixed attachments and empty-context translation.
-- **Dependency and rendering compatibility maintenance**: through #61, updated KaTeX, Zotero Plugin Toolkit, the Zotero ESLint configuration, and Prettier. The Toolkit import path and bundled KaTeX CSS were updated together, with regression coverage for formula rendering.
+- **Safer Zotero item resolution**: AIdea now handles deleted, unavailable, or unresolved Zotero item IDs consistently across document context, selection translation, notes, file intake, paper search, and author profiles.
+- **Improved attachment reliability**: missing parent items and attachments are treated as unavailable instead of leaking Zotero's internal `false` sentinel into application code.
+- **Compatibility with updated Zotero types**: adapted all single-item lookups to the stricter `zotero-types` 4.1.3 return signatures, with regression coverage for both existing and missing items.
+- **Development dependency maintenance**: updated `@types/node` to 26.1.2, ESLint to 10.8.0, Zotero Plugin Scaffold to 0.8.8, and `zotero-types` to 4.1.3 through #64 and #66.
 
-EPUB support in this release applies only to selection translation. Full-document translation is unchanged, and EPUB side-panel document chat is not included.
+This is a reliability and maintenance release with no new settings or visible interface changes.
 
-After updating, restart Zotero before testing the new behavior.
+After updating, restart Zotero before testing the new version.
 
 ## 更新内容
 
-- **EPUB 划词翻译与格式自动识别**：AIdea 现在支持在 Zotero EPUB 阅读器中直接翻译选中文本。现有划词翻译入口会自动识别当前打开的是 PDF 还是 EPUB，无需新增设置或手动切换文档格式。感谢 @senlinyy 在 #62 中提交这一功能。
-- **混合附件选择更准确**：同一 Zotero 条目同时包含 PDF 和 EPUB 附件时，AIdea 会使用当前阅读器中实际打开的附件，不再依赖附件排列顺序。
-- **缺少文档上下文时仍可翻译**：即使 PDF 或 EPUB 的全文内容尚未提取完成，划词翻译仍可继续使用；暂时为空的 EPUB 全文缓存也会自动重试。
-- **保持现有 PDF 工作流**：PDF 划词翻译和 PDF 侧栏文档对话继续保持原有行为，并新增了混合附件及空上下文翻译的回归保障。
-- **依赖与公式渲染兼容性维护**：通过 #61 更新 KaTeX、Zotero Plugin Toolkit、Zotero ESLint 配置和 Prettier；同时适配 Toolkit 新导入路径、同步更新内置 KaTeX 样式，并增加公式渲染回归测试。
+- **更安全的 Zotero 条目解析**：AIdea 现在会在文档上下文、划词翻译、笔记、文件导入、论文搜索和作者档案等路径中统一处理已删除、暂不可用或无法解析的 Zotero 条目 ID。
+- **提高附件处理可靠性**：缺失的父条目和附件现在会被视为不可用，不再让 Zotero 内部使用的 `false` 哨兵值进入应用逻辑。
+- **兼容新版 Zotero 类型定义**：所有单条目查询均已适配 `zotero-types` 4.1.3 更严格的返回类型，并增加现有条目和缺失条目的回归测试。
+- **开发依赖维护**：通过 #64 和 #66，将 `@types/node` 更新至 26.1.2、ESLint 更新至 10.8.0、Zotero Plugin Scaffold 更新至 0.8.8、`zotero-types` 更新至 4.1.3。
 
-本次 EPUB 支持仅适用于划词翻译。全文翻译功能没有变化，EPUB 侧栏文档对话暂不包含在本次更新中。
+这是一次可靠性与维护版本，没有新增设置或可见的界面变化。
 
-更新后请重启 Zotero，再测试相关功能。
+更新后请重启 Zotero，再测试新版本。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aidea-for-zotero",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aidea-for-zotero",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "katex": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aidea-for-zotero",
   "type": "module",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "AIdea: Free AI assistant for Zotero — Chat with AI directly in Zotero's side panel",
   "config": {
     "addonName": "AIdea",


### PR DESCRIPTION
## What changed

- bump AIdea from 3.3.0 to 3.3.1
- update the bilingual release notes for the Zotero item-resolution reliability fix and dependency maintenance
- keep README and user documentation unchanged because this release adds no settings, UI, or workflow changes

## Included fixes

- unified handling for Zotero's missing-item `false` sentinel from #66
- development dependency updates from #64

## Validation

- `npm run test:unit` — 408 passing
- `python test/pdfTranslator/test_bridge.py` — 95 passing
- `npm run build` — passed; generated `AIdea-3.3.1.xpi`
- `npm run lint:check` — passed
- generated manifest/update metadata report version 3.3.1 and Zotero compatibility 6.999–9.*