### PR TITLE
fix: harden chat store initialization

### DIFF
--- a/src/modules/contextPanel/libraryPanel.ts
+++ b/src/modules/contextPanel/libraryPanel.ts
@@ -19,6 +19,7 @@ import { config } from "../../../package.json";
 import {
   createGlobalConversation,
   getLatestEmptyGlobalConversation,
+  initChatStore,
 } from "../../utils/chatStore";
 import {
   activeConversationModeByLibrary,
@@ -96,6 +97,8 @@ export async function bootstrapSharedLibraryPanel(
   state.hasBootstrapped = true;
 
   try {
+    await initChatStore();
+
     const libraryID = resolveActiveLibraryID() || 1;
     let globalKey = Number(
       activeGlobalConversationByLibrary.get(libraryID) || 0,

--- a/src/modules/contextPanel/readerPanel.ts
+++ b/src/modules/contextPanel/readerPanel.ts
@@ -28,6 +28,7 @@ import {
 import {
   createPaperConversation,
   getLatestPaperConversation,
+  initChatStore,
 } from "../../utils/chatStore";
 import { getPanelI18n } from "./i18n";
 
@@ -100,6 +101,8 @@ export async function bootstrapSharedReaderPanel(
   state.hasBootstrapped = true;
 
   try {
+    await initChatStore();
+
     // ── Resolve active paper conversation key ──
     // Each PDF item can have multiple conversations. Resolve the active one
     // (or create it if none exists) and store in activePaperConversationByItem.

--- a/src/utils/chatStore.ts
+++ b/src/utils/chatStore.ts
@@ -256,8 +256,6 @@ async function initializeChatStore(): Promise<void> {
        ON ${CHAT_MESSAGES_TABLE} (conversation_key, timestamp, id)`,
     );
 
-    await migratePersistedModelOutputs();
-
     await Zotero.DB.queryAsync(
       `CREATE TABLE IF NOT EXISTS ${CHAT_TREE_STATE_TABLE} (
         conversation_key INTEGER PRIMARY KEY,
@@ -317,6 +315,10 @@ async function initializeChatStore(): Promise<void> {
   // the library and reader panels. Each migration gets its own transaction so
   // one bad legacy row cannot prevent the store from becoming usable.
   await runOptionalChatStoreMigration(
+    "model-output-normalization",
+    migratePersistedModelOutputs,
+  );
+  await runOptionalChatStoreMigration(
     "linear-conversations-to-tree",
     migrateLinearConversationsToTree,
   );
@@ -339,9 +341,10 @@ export async function migratePersistedModelOutputs(): Promise<void> {
      FROM ${CHAT_MESSAGES_TABLE}
      WHERE role = 'assistant'
        AND (
-         lower(text) LIKE '%<think>%'
-         OR lower(text) LIKE '%<thought>%'
+         lower(text) LIKE ?
+         OR lower(text) LIKE ?
        )`,
+    ["%<think>%", "%<thought>%"],
   )) as Array<{ messageId?: unknown; text?: unknown }> | undefined;
   for (const row of assistantCandidates || []) {
     const messageId = normalizeTreeId(row.messageId);
@@ -365,9 +368,10 @@ export async function migratePersistedModelOutputs(): Promise<void> {
      FROM ${CHAT_MESSAGES_TABLE}
      WHERE context_refs_json IS NOT NULL
        AND (
-         lower(context_refs_json) LIKE '%<think>%'
-         OR lower(context_refs_json) LIKE '%<thought>%'
+         lower(context_refs_json) LIKE ?
+         OR lower(context_refs_json) LIKE ?
        )`,
+    ["%<think>%", "%<thought>%"],
   )) as Array<{ messageId?: unknown; contextRefsJson?: unknown }> | undefined;
   for (const row of contextCandidates || []) {
     const messageId = normalizeTreeId(row.messageId);

--- a/src/utils/chatStore.ts
+++ b/src/utils/chatStore.ts
@@ -99,7 +99,20 @@ function normalizeLimit(limit: number, fallback: number): number {
   return Math.max(1, Math.floor(limit));
 }
 
-export async function initChatStore(): Promise<void> {
+let chatStoreInitialization: Promise<void> | null = null;
+
+export function initChatStore(): Promise<void> {
+  if (!chatStoreInitialization) {
+    chatStoreInitialization = initializeChatStore().catch((err) => {
+      // A core-schema failure must be retryable when a panel opens later.
+      chatStoreInitialization = null;
+      throw err;
+    });
+  }
+  return chatStoreInitialization;
+}
+
+async function initializeChatStore(): Promise<void> {
   await Zotero.DB.executeTransaction(async () => {
     await Zotero.DB.queryAsync(
       `CREATE TABLE IF NOT EXISTS ${CHAT_MESSAGES_TABLE} (
@@ -253,8 +266,6 @@ export async function initChatStore(): Promise<void> {
       )`,
     );
 
-    await migrateLinearConversationsToTree();
-
     await Zotero.DB.queryAsync(
       `CREATE TABLE IF NOT EXISTS ${GLOBAL_CONVERSATIONS_TABLE} (
         conversation_key INTEGER PRIMARY KEY,
@@ -301,6 +312,25 @@ export async function initChatStore(): Promise<void> {
       );
     }
   });
+
+  // Historical cleanup must never roll back the core tables required to open
+  // the library and reader panels. Each migration gets its own transaction so
+  // one bad legacy row cannot prevent the store from becoming usable.
+  await runOptionalChatStoreMigration(
+    "linear-conversations-to-tree",
+    migrateLinearConversationsToTree,
+  );
+}
+
+async function runOptionalChatStoreMigration(
+  name: string,
+  migration: () => Promise<void>,
+): Promise<void> {
+  try {
+    await Zotero.DB.executeTransaction(migration);
+  } catch (err) {
+    ztoolkit.log(`LLM: Optional chat store migration failed (${name})`, err);
+  }
 }
 
 export async function migratePersistedModelOutputs(): Promise<void> {

--- a/test/chatStoreInitialization.test.ts
+++ b/test/chatStoreInitialization.test.ts
@@ -1,0 +1,150 @@
+import { assert } from "chai";
+
+import { initChatStore } from "../src/utils/chatStore";
+
+describe("chatStore initialization", function () {
+  it("retries core setup, commits it before migrations, and initializes once", async function () {
+    let tables = new Map<string, Set<string>>();
+    let transactionCount = 0;
+    let coreAttemptCount = 0;
+    let failCoreOnce = true;
+    const logs: string[] = [];
+
+    const cloneTables = () =>
+      new Map([...tables].map(([name, columns]) => [name, new Set(columns)]));
+
+    const initialColumns = (table: string): string[] => {
+      if (table === "zotero_ai_chat_messages") {
+        return [
+          "id",
+          "conversation_key",
+          "role",
+          "text",
+          "timestamp",
+          "selected_text",
+          "selected_texts_json",
+          "selected_text_sources_json",
+          "selected_text_paper_contexts_json",
+          "paper_contexts_json",
+          "screenshot_images",
+          "attachments_json",
+          "model_name",
+          "reasoning_summary",
+          "reasoning_details",
+        ];
+      }
+      if (table === "zotero_ai_chat_tree_state") {
+        return ["conversation_key", "active_root_id", "active_leaf_id"];
+      }
+      if (table === "zotero_ai_global_conversations") {
+        return ["conversation_key", "library_id", "created_at", "title"];
+      }
+      if (table === "zotero_ai_paper_conversations") {
+        return ["conversation_key", "parent_item_id", "created_at", "title"];
+      }
+      return [];
+    };
+
+    (globalThis as any).ztoolkit = {
+      log(message: string) {
+        logs.push(message);
+      },
+    };
+    (globalThis as any).Zotero = {
+      DB: {
+        async executeTransaction<T>(fn: () => Promise<T>): Promise<T> {
+          transactionCount += 1;
+          const snapshot = cloneTables();
+          try {
+            return await fn();
+          } catch (err) {
+            tables = snapshot;
+            throw err;
+          }
+        },
+        async columnQueryAsync(sql: string): Promise<number[] | false> {
+          if (sql.includes("SELECT DISTINCT conversation_key")) {
+            throw new Error("injected legacy migration failure");
+          }
+          return false;
+        },
+        async queryAsync(sql: string): Promise<Array<{ name: string }>> {
+          if (
+            sql.includes("CREATE TABLE IF NOT EXISTS zotero_ai_chat_messages")
+          ) {
+            coreAttemptCount += 1;
+            if (failCoreOnce) {
+              failCoreOnce = false;
+              throw new Error("injected core schema failure");
+            }
+          }
+
+          const createMatch = sql.match(
+            /CREATE TABLE IF NOT EXISTS\s+([a-z0-9_]+)/i,
+          );
+          if (createMatch) {
+            const table = createMatch[1];
+            if (!tables.has(table)) {
+              tables.set(table, new Set(initialColumns(table)));
+            }
+            return [];
+          }
+
+          const pragmaMatch = sql.match(/PRAGMA table_info\(([^)]+)\)/i);
+          if (pragmaMatch) {
+            return [...(tables.get(pragmaMatch[1]) || [])].map((name) => ({
+              name,
+            }));
+          }
+
+          const alterMatch = sql.match(
+            /ALTER TABLE\s+([a-z0-9_]+)\s+ADD COLUMN\s+([a-z0-9_]+)/i,
+          );
+          if (alterMatch) {
+            tables.get(alterMatch[1])?.add(alterMatch[2]);
+          }
+          return [];
+        },
+      },
+    };
+
+    let coreFailure: unknown;
+    try {
+      await initChatStore();
+    } catch (err) {
+      coreFailure = err;
+    }
+    assert.match(String(coreFailure), /injected core schema failure/);
+    assert.isEmpty([...tables.keys()]);
+
+    await Promise.all([initChatStore(), initChatStore()]);
+    await initChatStore();
+
+    assert.equal(coreAttemptCount, 2);
+    assert.isAtLeast(transactionCount, 3);
+    assert.sameMembers(
+      [...tables.keys()],
+      [
+        "zotero_ai_chat_messages",
+        "zotero_ai_chat_tree_state",
+        "zotero_ai_global_conversations",
+        "zotero_ai_paper_conversations",
+      ],
+    );
+    assert.includeMembers(
+      [...(tables.get("zotero_ai_chat_messages") || [])],
+      ["context_refs_json", "parent_id", "active_child_id", "branch_index"],
+    );
+    assert.include(
+      [...(tables.get("zotero_ai_global_conversations") || [])],
+      "is_pinned",
+    );
+    assert.include(
+      [...(tables.get("zotero_ai_paper_conversations") || [])],
+      "is_pinned",
+    );
+    assert.deepEqual(logs, [
+      "LLM: Optional chat store migration failed (linear-conversations-to-tree)",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- make chat-store initialization single-flight and retryable after core-schema failures
- commit the required schema before running historical data migrations
- isolate both model-output normalization and linear-to-tree migration failures from panel startup
- bind SQLite `LIKE` patterns instead of embedding wildcard literals
- surface a visible retry action when reader or library panel bootstrapping fails

## Root cause

Historical cleanup ran inside the same transaction as the tables required by the AIdea panels. A migration failure could roll back the core schema and leave the panel empty. Zotero's SQLite wrapper also requires `LIKE` patterns to be passed as bindings.

Closes #71.

## Validation

- `npm run test:unit` — 422 passing
- `npm run lint:check`
- `npm run build`
- locally installed in Zotero and verified that the panel initializes after a clean restart