### PR TITLE
fix: support Zotero 10 and prepare v3.4.1

### DIFF
--- a/.github/release_notes.md
+++ b/.github/release_notes.md
@@ -1,43 +1,23 @@
 ## ✨ What's Changed
 
-- 📚 **EPUB context chat**: AIdea can now use EPUB books as the active document context in Zotero’s reader panel. It supports EPUB 3 navigation documents and EPUB 2 NCX structure, with semantic headings and spine order as fallbacks for less structured books. Thanks @senlinyy for contributing the document-adapter and EPUB parsing work in #69; the integrated commit preserves the original Git authorship.
+- 🧩 **Zotero 10 compatibility**: Fixed the incompatible-version error when installing AIdea on Zotero 10. The XPI and automatic-update manifest now both support Zotero 10.0.x, while retaining Zotero 7–9 compatibility. Thanks @Saywhatyousay and @JorgeESantos for reporting and confirming #77.
 
-- 🎯 **Deterministic, bounded retrieval**: Explicit chapter references, whole-book requests, and ambiguous follow-ups are routed locally. AIdea sends only bounded relevant excerpts to the answering model and does not make an additional model request to plan sections.
+- 🗂️ **Correct library scope**: Use Zotero 10's `getSelectedLibraryIDs()` API instead of its removed singular getter. Selecting a group library now keeps the correct conversation scope. In a multi-library view, AIdea uses the selected items' library when it is unambiguous; otherwise it falls back to the personal library. Zotero 7–9 keep their existing API fallback.
 
-- 🌐 **Context-aware EPUB selection translation**: EPUB selections use bounded, selection-anchored book context directly, without a separate cold-start request. Selection translation remains automatic, with no additional custom-instruction setting.
+- 🛡️ **Resilient selection fallback**: A library-selection API error no longer prevents AIdea from checking the selected items. Regression tests cover the new API, older Zotero versions, group libraries, and ambiguous multi-library selections.
 
-- 🛡️ **Safer EPUB processing**: Archive paths, entry counts, individual decompressed entries, total extracted text, and normalized book text are bounded to prevent malformed or oversized EPUB files from exhausting Zotero resources.
+- ✅ **Validation**: Passed 447 automated tests, formatting and lint checks, and a production build. Local Windows testing on Zotero 10.0.1 covered native XPI compatibility checks, installation, restart, disable/re-enable, group and multi-library selection, settings, and PDF/EPUB reader panels. These smoke tests did not send requests to a model provider.
 
-- 🐛 **Reliable panel startup**: Required chat tables are committed before optional historical migrations run. Failed core initialization can be retried, migration failures no longer leave the AIdea panel blank, and Zotero SQLite `LIKE` patterns use bound parameters. Thanks @senlinyy for reporting #71.
-
-- 🔄 **PDF and history compatibility**: Existing PDF context behavior and legacy `basePdf` conversation data remain compatible while the shared document-adapter architecture supports future formats.
-
-- ✅ **Validation**: The release has passed 438 TypeScript tests, formatting and lint checks, production builds, reproducible EPUB 2/3 fixture tests, GitHub CI, and local Zotero verification covering EPUB reading, panel initialization, and selection translation.
-
-- 🔁 **After updating**: Restart Zotero, then open a PDF or EPUB and use the same AIdea reader panel. No additional mode switch is required.
-
-- 🔒 **Privacy and model requests**: EPUB extraction and section routing run locally. Only the bounded context selected for the current request is sent to the configured model provider. No additional planning-model request is made.
-
-- ⚠️ **EPUB structure**: Retrieval quality benefits from publisher-provided navigation and chapter structure. For less structured books, AIdea falls back to semantic headings and spine reading order.
+- 🔁 **How to update**: Install `AIdea-3.4.1.xpi` from this release, or use Zotero's plugin update check, then restart Zotero. There is no need to edit or repackage `manifest.json` manually.
 
 ## 📝 更新内容
 
-- 📚 **EPUB 上下文对话**：AIdea 现在可以在 Zotero 阅读器侧边栏中把 EPUB 图书作为当前文档上下文。支持 EPUB 3 Navigation Document 和 EPUB 2 NCX 目录结构；对于结构不完整的图书，会使用语义标题和 spine 阅读顺序作为后备。感谢 @senlinyy 在 #69 中贡献文档适配器与 EPUB 解析工作；整合后的提交保留了原始 Git 作者信息。
+- 🧩 **兼容 Zotero 10**：修复在 Zotero 10 中安装 AIdea 时提示版本不兼容的问题。XPI 安装包和自动更新清单现已同时支持 Zotero 10.0.x，并保留 Zotero 7–9 兼容性。感谢 @Saywhatyousay 和 @JorgeESantos 在 #77 中报告并确认问题。
 
-- 🎯 **本地确定性有界检索**：明确章节、全书请求和模糊追问均在本地完成章节路由。AIdea 只把有界的相关原文片段发送给回答模型，不会为了规划章节而额外调用一次模型。
+- 🗂️ **正确识别资料库范围**：改用 Zotero 10 的 `getSelectedLibraryIDs()` 接口，不再调用已移除的单资料库接口。选择群组文库时保留正确的会话范围；同时选择多个资料库时，优先采用所选条目明确所属的资料库，范围不明确时回退到个人文库。Zotero 7–9 继续使用原有接口作为后备。
 
-- 🌐 **带上下文的 EPUB 划词翻译**：EPUB 划词翻译直接使用以选中文本为锚点的有界图书上下文，不再执行单独的冷启动请求。划词翻译仍然自动工作，不增加自定义指令设置。
+- 🛡️ **更可靠的选择回退**：资料库选择接口报错时，仍会继续检查所选条目，不再直接跳过。新增回归测试覆盖新旧 Zotero 接口、群组文库和跨资料库选择。
 
-- 🛡️ **更安全的 EPUB 处理**：对压缩包路径、条目数量、单个解压条目、累计提取文本和规范化图书文本设置明确上限，避免异常或超大 EPUB 占用过多 Zotero 资源。
+- ✅ **验证情况**：已通过 447 项自动化测试、格式与 lint 检查及生产构建。在 Windows 的 Zotero 10.0.1 中验证了原生 XPI 兼容性检查、安装、重启、禁用后重新启用、群组与多资料库选择、设置页及 PDF/EPUB 阅读器面板。本轮冒烟测试未向模型服务商发送请求。
 
-- 🐛 **面板启动更加可靠**：聊天所需的核心数据表会先提交，再运行可选的历史迁移。核心初始化失败后可以重试，迁移失败不再导致 AIdea 面板空白，同时 Zotero SQLite 的 `LIKE` 查询改为绑定参数。感谢 @senlinyy 报告 #71。
-
-- 🔄 **兼容现有 PDF 和历史记录**：原有 PDF 上下文行为保持不变，并继续兼容旧版 `basePdf` 对话数据；共享文档适配器架构也为后续格式扩展提供统一入口。
-
-- ✅ **验证情况**：已通过 438 项 TypeScript 测试、格式与 lint 检查、生产构建、可复现的 EPUB 2/3 fixture 测试、GitHub CI，以及覆盖 EPUB 阅读、面板初始化和划词翻译的本地 Zotero 验证。
-
-- 🔁 **更新后操作**：请重启 Zotero，然后打开 PDF 或 EPUB，直接使用同一个 AIdea 阅读器侧边栏，无需切换额外模式。
-
-- 🔒 **隐私与模型调用**：EPUB 内容提取和章节路由均在本地完成，只有针对当前请求选出的有界上下文会发送给已配置的模型服务商，不会额外调用章节规划模型。
-
-- ⚠️ **EPUB 结构说明**：检索效果会受图书内置目录和章节结构影响。对于结构不完整的图书，AIdea 会使用语义标题和 spine 阅读顺序作为后备。
+- 🔁 **更新方法**：安装本次发布的 `AIdea-3.4.1.xpi`，或使用 Zotero 的插件更新检查，然后重启 Zotero。无需手动修改或重新打包 `manifest.json`。

--- a/.github/release_notes.md
+++ b/.github/release_notes.md
@@ -8,7 +8,7 @@
 
 - 🌐 **One-time localized update notice**: Added a once-per-version Zotero 10 compatibility notice in all 12 interface languages, including restart and official update guidance without adding a new Settings or PDF/EPUB mode.
 
-- ✅ **Validation**: Passed 447 automated tests, formatting and lint checks, and a production build. Local Windows testing on Zotero 10.0.1 covered native XPI compatibility checks, installation, restart, disable/re-enable, group and multi-library selection, settings, and PDF/EPUB reader panels. These smoke tests did not send requests to a model provider.
+- ✅ **Validation**: Passed 451 TypeScript unit tests and 110 Python bridge tests, formatting and lint checks, and a production build. Full local QA on Windows with Zotero 10.0.1 covered XPI installation, restart, disable/re-enable, no/single/multi-selection scope, settings, global/PDF/EPUB chat, attachments, conversation history, notes, image generation, and a 27-page monolingual and bilingual PDF translation using the existing OpenAI Codex connection only. Translation pause/resume also verified Windows process-tree cleanup and a fresh bridge restart. No group library was available in the local profile; group-library scope is covered by automated regression tests.
 
 - 🔁 **How to update**: Install `AIdea-3.4.1.xpi` from this release, or use Zotero's plugin update check, then restart Zotero. There is no need to edit or repackage `manifest.json` manually.
 
@@ -22,6 +22,6 @@
 
 - 🌐 **一次性多语言更新提示**：新增覆盖全部 12 种界面语言、每个版本只显示一次的 Zotero 10 兼容提示，包含重启和官方更新说明，不增加新的设置或 PDF/EPUB 模式。
 
-- ✅ **验证情况**：已通过 447 项自动化测试、格式与 lint 检查及生产构建。在 Windows 的 Zotero 10.0.1 中验证了原生 XPI 兼容性检查、安装、重启、禁用后重新启用、群组与多资料库选择、设置页及 PDF/EPUB 阅读器面板。本轮冒烟测试未向模型服务商发送请求。
+- ✅ **验证情况**：已通过 451 项 TypeScript 单元测试、110 项 Python bridge 测试、格式与 lint 检查及生产构建。在 Windows 的 Zotero 10.0.1 中完成了全功能本机验收，覆盖 XPI 安装、重启、禁用后重新启用、无选择/单选/多选范围、设置页、全局/PDF/EPUB 对话、附件、会话历史、笔记、图片生成，以及仅使用现有 OpenAI Codex 连接完成的 27 页单语与双语 PDF 全文翻译；暂停与继续还验证了 Windows 进程树清理及新 bridge 重启。本机 Profile 没有群组文库，该范围由自动化回归测试覆盖。
 
 - 🔁 **更新方法**：安装本次发布的 `AIdea-3.4.1.xpi`，或使用 Zotero 的插件更新检查，然后重启 Zotero。无需手动修改或重新打包 `manifest.json`。

--- a/.github/release_notes.md
+++ b/.github/release_notes.md
@@ -1,10 +1,12 @@
 ## ✨ What's Changed
 
-- 🧩 **Zotero 10 compatibility**: Fixed the incompatible-version error when installing AIdea on Zotero 10. The XPI and automatic-update manifest now both support Zotero 10.0.x, while retaining Zotero 7–9 compatibility. Thanks @Saywhatyousay and @JorgeESantos for reporting and confirming #77.
+- 🧩 **Zotero 10 compatibility**: Fixed the incompatible-version error when installing AIdea on Zotero 10. The XPI and automatic-update manifest now both support Zotero 10.0.x, while retaining Zotero 7–9 compatibility. Thanks @Saywhatyousay for reporting and @JorgeESantos for confirming #77.
 
 - 🗂️ **Correct library scope**: Use Zotero 10's `getSelectedLibraryIDs()` API instead of its removed singular getter. Selecting a group library now keeps the correct conversation scope. In a multi-library view, AIdea uses the selected items' library when it is unambiguous; otherwise it falls back to the personal library. Zotero 7–9 keep their existing API fallback.
 
 - 🛡️ **Resilient selection fallback**: A library-selection API error no longer prevents AIdea from checking the selected items. Regression tests cover the new API, older Zotero versions, group libraries, and ambiguous multi-library selections.
+
+- 🌐 **One-time localized update notice**: Added a once-per-version Zotero 10 compatibility notice in all 12 interface languages, including restart and official update guidance without adding a new Settings or PDF/EPUB mode.
 
 - ✅ **Validation**: Passed 447 automated tests, formatting and lint checks, and a production build. Local Windows testing on Zotero 10.0.1 covered native XPI compatibility checks, installation, restart, disable/re-enable, group and multi-library selection, settings, and PDF/EPUB reader panels. These smoke tests did not send requests to a model provider.
 
@@ -12,11 +14,13 @@
 
 ## 📝 更新内容
 
-- 🧩 **兼容 Zotero 10**：修复在 Zotero 10 中安装 AIdea 时提示版本不兼容的问题。XPI 安装包和自动更新清单现已同时支持 Zotero 10.0.x，并保留 Zotero 7–9 兼容性。感谢 @Saywhatyousay 和 @JorgeESantos 在 #77 中报告并确认问题。
+- 🧩 **兼容 Zotero 10**：修复在 Zotero 10 中安装 AIdea 时提示版本不兼容的问题。XPI 安装包和自动更新清单现已同时支持 Zotero 10.0.x，并保留 Zotero 7–9 兼容性。感谢 @Saywhatyousay 报告问题，并感谢 @JorgeESantos 确认 #77。
 
 - 🗂️ **正确识别资料库范围**：改用 Zotero 10 的 `getSelectedLibraryIDs()` 接口，不再调用已移除的单资料库接口。选择群组文库时保留正确的会话范围；同时选择多个资料库时，优先采用所选条目明确所属的资料库，范围不明确时回退到个人文库。Zotero 7–9 继续使用原有接口作为后备。
 
 - 🛡️ **更可靠的选择回退**：资料库选择接口报错时，仍会继续检查所选条目，不再直接跳过。新增回归测试覆盖新旧 Zotero 接口、群组文库和跨资料库选择。
+
+- 🌐 **一次性多语言更新提示**：新增覆盖全部 12 种界面语言、每个版本只显示一次的 Zotero 10 兼容提示，包含重启和官方更新说明，不增加新的设置或 PDF/EPUB 模式。
 
 - ✅ **验证情况**：已通过 447 项自动化测试、格式与 lint 检查及生产构建。在 Windows 的 Zotero 10.0.1 中验证了原生 XPI 兼容性检查、安装、重启、禁用后重新启用、群组与多资料库选择、设置页及 PDF/EPUB 阅读器面板。本轮冒烟测试未向模型服务商发送请求。
 

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -14,7 +14,7 @@
       "id": "__addonID__",
       "update_url": "__updateURL__",
       "strict_min_version": "6.999",
-      "strict_max_version": "9.*"
+      "strict_max_version": "10.0.*"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aidea-for-zotero",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aidea-for-zotero",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "katex": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aidea-for-zotero",
   "type": "module",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "AIdea: Free AI assistant for Zotero — Chat with AI directly in Zotero's side panel",
   "config": {
     "addonName": "AIdea",

--- a/src/modules/contextPanel/portalScope.ts
+++ b/src/modules/contextPanel/portalScope.ts
@@ -2,21 +2,43 @@ import { GLOBAL_CONVERSATION_KEY_BASE } from "./constants";
 import { normalizePositiveInt } from "./normalizers";
 import type { GlobalPortalItem } from "./types";
 
+function getSingleLibraryID(values: unknown): number | null {
+  if (!Array.isArray(values)) return null;
+  const ids = new Set(
+    values.map(normalizePositiveInt).filter((id): id is number => id !== null),
+  );
+  return ids.size === 1 ? [...ids][0] : null;
+}
+
 export function resolveActiveLibraryID(): number | null {
   try {
     const pane = Zotero.getActiveZoteroPane?.() as
       | {
+          getSelectedLibraryIDs?: () => unknown;
           getSelectedLibraryID?: () => unknown;
           getSelectedItems?: () => Zotero.Item[];
         }
       | undefined;
-    const selectedLibraryID = normalizePositiveInt(
-      pane?.getSelectedLibraryID?.(),
-    );
-    if (selectedLibraryID) return selectedLibraryID;
+    try {
+      // Zotero 10's singular getter throws, even for a single selection.
+      // Prefer the plural API and only use the old getter on older versions.
+      const selectedLibraryID = getSingleLibraryID(
+        typeof pane?.getSelectedLibraryIDs === "function"
+          ? pane.getSelectedLibraryIDs()
+          : [pane?.getSelectedLibraryID?.()],
+      );
+      if (selectedLibraryID) return selectedLibraryID;
+    } catch (_err) {
+      void _err;
+    }
+
+    // A multi-library view has no single scope. Use selected items only when
+    // they agree on a library; otherwise keep the personal-library fallback.
     const selectedItems = pane?.getSelectedItems?.() || [];
-    const firstItemLibrary = normalizePositiveInt(selectedItems[0]?.libraryID);
-    if (firstItemLibrary) return firstItemLibrary;
+    const selectedItemLibraryID = getSingleLibraryID(
+      selectedItems.map((item) => item?.libraryID),
+    );
+    if (selectedItemLibraryID) return selectedItemLibraryID;
   } catch (_err) {
     void _err;
   }

--- a/src/modules/pdfTranslator/processRunner.ts
+++ b/src/modules/pdfTranslator/processRunner.ts
@@ -9,6 +9,8 @@ const IS_WIN_PROC =
   (typeof Zotero !== "undefined" && Zotero.isWin) ||
   (typeof navigator !== "undefined" && /win/i.test(navigator.platform));
 
+declare const Services: any;
+
 export interface RunningProcess {
   /** Kill the subprocess tree */
   kill(): void;
@@ -63,6 +65,8 @@ export function launchProcess(exe: string, args: string[]): RunningProcess {
 
   return {
     kill() {
+      const pid = Number((proc as any).pid || 0);
+      if (IS_WIN_PROC && pid > 0 && killWindowsProcessTree(pid)) return;
       try {
         proc.kill();
       } catch {
@@ -71,4 +75,43 @@ export function launchProcess(exe: string, args: string[]): RunningProcess {
     },
     done,
   };
+}
+
+/**
+ * nsIProcess.kill() only terminates the direct child on Windows. The bridge
+ * launches pdf2zh_next, which then launches Python worker processes, so a
+ * direct kill leaves those workers orphaned and disconnects them from the
+ * temporary OAuth proxy. Use taskkill /T for an atomic best-effort tree stop.
+ */
+function killWindowsProcessTree(pid: number): boolean {
+  try {
+    const systemDir = Services.dirsvc.get(
+      "SysD",
+      (Components.interfaces as any).nsIFile,
+    );
+    const taskkillFile = systemDir.clone();
+    taskkillFile.append("taskkill.exe");
+    if (!taskkillFile.exists()) return false;
+
+    const killer = (Components.classes as any)[
+      "@mozilla.org/process/util;1"
+    ].createInstance((Components.interfaces as any).nsIProcess);
+    killer.init(taskkillFile);
+    try {
+      killer.startHidden = true;
+    } catch {
+      /* older Gecko may not support */
+    }
+    try {
+      killer.noShell = true;
+    } catch {
+      /* best effort */
+    }
+
+    const killArgs = ["/PID", String(pid), "/T", "/F"];
+    killer.run(true, killArgs, killArgs.length);
+    return Number(killer.exitValue) === 0;
+  } catch {
+    return false;
+  }
 }

--- a/src/modules/pdfTranslator/translateTabController.ts
+++ b/src/modules/pdfTranslator/translateTabController.ts
@@ -10,6 +10,7 @@
 import { getModelChoices } from "../contextPanel/setupHandlers/controllers/modelSelectionController";
 import { getPanelI18n } from "../contextPanel/i18n";
 import type { ProgressData, TranslationStats, WarningStats } from "./types";
+import { restartPausedTranslation } from "./translationLifecycle";
 
 /* ── Per-tab model pref key ── */
 
@@ -898,12 +899,23 @@ export function initTranslateTab(body: Element): void {
       if (!session.activeController) return;
       try {
         if (session.isPaused) {
-          // Resume — re-start translation to continue from cache
-          session.isPaused = false;
+          // Resume from pdf2zh_next's cache with a fresh bridge/OAuth proxy.
           const i18n = getPanelI18n();
           pauseBtn.textContent = `⏸ ${i18n.trPause}`;
           pauseBtn.className = "llm-tr-btn llm-tr-btn-warning";
           consoleLog(body, `▶️ ${i18n.trLogResumed}`, "info");
+          restartPausedTranslation(
+            session,
+            () => startTranslation(body),
+            (err) => {
+              consoleLog(
+                body,
+                `❌ ${i18n.trLogPauseError(String(err))}`,
+                "error",
+              );
+              restoreTranslationControls(body);
+            },
+          );
         } else {
           // Pause
           session.activeController.pause();

--- a/src/modules/pdfTranslator/translationLifecycle.ts
+++ b/src/modules/pdfTranslator/translationLifecycle.ts
@@ -1,0 +1,22 @@
+export interface PausedTranslationSession {
+  isPaused: boolean;
+  activeController: unknown;
+}
+
+/**
+ * Resume a cached translation by starting a fresh bridge process.
+ *
+ * pdf2zh_next owns the page cache, so the paused controller itself cannot be
+ * resumed after its process tree has been stopped. Clearing the old controller
+ * before invoking restart also prevents the normal "already running" guard
+ * from blocking the new bridge.
+ */
+export function restartPausedTranslation(
+  session: PausedTranslationSession,
+  restart: () => Promise<void>,
+  onError: (error: unknown) => void,
+): void {
+  session.activeController = null;
+  session.isPaused = false;
+  void restart().catch(onError);
+}

--- a/src/modules/updateNotice.ts
+++ b/src/modules/updateNotice.ts
@@ -4,7 +4,7 @@ import { getPanelLang, type PanelLang } from "./contextPanel/i18n";
 import { getUiLanguageOption } from "./contextPanel/languages";
 import { applyCurrentThemeToRoot } from "./contextPanel/theme";
 
-export const NOTICE_ID = "v3.4.0-epub-context-chat-v1";
+export const NOTICE_ID = "v3.4.1-zotero-10-compatibility-v1";
 const NOTICE_PREF = `${config.prefsPrefix}.updateNoticeSeen`;
 
 type UpdateNoticeCopy = {
@@ -907,26 +907,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
   {
     "en-US": {
       eyebrow: "Update",
-      title: "EPUB context chat and more reliable panel startup",
-      lead: "AIdea can now use EPUB books as document context in Zotero's reader panel, with local section routing and bounded retrieval from EPUB 2/3 structure.",
-      note: "Restart Zotero after updating. Open a PDF or EPUB and use the same AIdea reader panel; no additional mode switch is required.",
+      title: "Zotero 10 compatibility",
+      lead: "AIdea can now be installed and used on Zotero 10.0.x while retaining support for Zotero 7–9.",
+      note: "Restart Zotero after updating. Install the official XPI or use automatic update; there is no need to edit manifest.json manually.",
       alsoLabel: "This update includes",
       alsoItems: [
         {
-          label: "EPUB side-panel chat",
-          text: "Ask about chapters or the whole book directly in the Zotero EPUB reader.",
+          label: "Official installation and updates",
+          text: "The official XPI and automatic-update manifest now accept Zotero 10.0.x.",
         },
         {
-          label: "Local bounded retrieval",
-          text: "Publisher structure, follow-up scope, and whole-book sampling are handled locally without an additional planning-model request.",
+          label: "Correct library scope",
+          text: "Zotero 10's plural library-selection API keeps personal, group, and multi-library conversation scope correct.",
         },
         {
-          label: "Context-aware selection translation",
-          text: "EPUB selections use bounded book context directly, without a separate cold-start request.",
+          label: "Zotero 7–9 retained",
+          text: "Older Zotero versions continue to use the existing fallback API.",
         },
         {
-          label: "Reliable and safe",
-          text: "Panel initialization can recover from optional migration failures, and malformed or oversized EPUB archives are bounded.",
+          label: "No new modes",
+          text: "Settings and the existing PDF/EPUB side panels keep the same workflow without an extra mode.",
         },
       ],
       exampleLabel: "",
@@ -936,26 +936,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "zh-CN": {
       eyebrow: "更新提示",
-      title: "EPUB 上下文对话与更可靠的面板启动",
-      lead: "AIdea 现在可以在 Zotero EPUB 阅读器侧边栏中把图书作为文档上下文，并根据 EPUB 2/3 结构在本地完成章节路由和有界检索。",
-      note: "更新后请重启 Zotero。打开 PDF 或 EPUB 后直接使用同一个 AIdea 阅读器面板，无需切换额外模式。",
+      title: "兼容 Zotero 10",
+      lead: "AIdea 现在可以在 Zotero 10.0.x 中安装和使用，同时继续支持 Zotero 7–9。",
+      note: "更新后请重启 Zotero。请安装官方 XPI 或使用自动更新，无需手动修改 manifest.json。",
       alsoLabel: "本次更新包括",
       alsoItems: [
         {
-          label: "EPUB 侧边栏对话",
-          text: "可以直接在 Zotero EPUB 阅读器中询问具体章节或整本图书。",
+          label: "官方安装与自动更新兼容",
+          text: "官方 XPI 和自动更新清单现已支持 Zotero 10.0.x。",
         },
         {
-          label: "本地有界检索",
-          text: "出版目录结构、追问范围和全书采样均在本地处理，不会额外调用模型规划章节。",
+          label: "资料库范围修复",
+          text: "改用 Zotero 10 的复数资料库选择接口，确保个人、群组和多资料库会话范围正确。",
         },
         {
-          label: "带上下文的划词翻译",
-          text: "EPUB 划词直接使用有界图书上下文，不再执行单独的冷启动请求。",
+          label: "保留 Zotero 7–9 支持",
+          text: "旧版 Zotero 继续使用现有后备接口。",
         },
         {
-          label: "启动可靠且处理安全",
-          text: "可选迁移失败后面板仍可恢复，异常或超大的 EPUB 压缩包也会受到明确限制。",
+          label: "不增加新模式",
+          text: "设置页以及现有 PDF/EPUB 侧边栏继续使用原有流程，无需切换额外模式。",
         },
       ],
       exampleLabel: "",
@@ -965,26 +965,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "zh-TW": {
       eyebrow: "更新提示",
-      title: "EPUB 上下文對話與更可靠的面板啟動",
-      lead: "AIdea 現在可以在 Zotero EPUB 閱讀器側邊欄中把圖書作為文件上下文，並依 EPUB 2/3 結構在本地完成章節路由和有界檢索。",
-      note: "更新後請重新啟動 Zotero。開啟 PDF 或 EPUB 後直接使用同一個 AIdea 閱讀器面板，無需切換額外模式。",
+      title: "相容 Zotero 10",
+      lead: "AIdea 現在可以在 Zotero 10.0.x 中安裝和使用，同時繼續支援 Zotero 7–9。",
+      note: "更新後請重新啟動 Zotero。請安裝官方 XPI 或使用自動更新，無需手動修改 manifest.json。",
       alsoLabel: "本次更新包括",
       alsoItems: [
         {
-          label: "EPUB 側邊欄對話",
-          text: "可以直接在 Zotero EPUB 閱讀器中詢問特定章節或整本圖書。",
+          label: "官方安裝與自動更新相容",
+          text: "官方 XPI 與自動更新清單現已支援 Zotero 10.0.x。",
         },
         {
-          label: "本地有界檢索",
-          text: "出版目錄結構、追問範圍與全書取樣均在本地處理，不會額外呼叫模型規劃章節。",
+          label: "資料庫範圍修正",
+          text: "改用 Zotero 10 的複數資料庫選取介面，確保個人、群組與多資料庫對話範圍正確。",
         },
         {
-          label: "帶上下文的劃詞翻譯",
-          text: "EPUB 劃詞直接使用有界圖書上下文，不再執行單獨的冷啟動請求。",
+          label: "保留 Zotero 7–9 支援",
+          text: "舊版 Zotero 繼續使用現有的後備介面。",
         },
         {
-          label: "啟動可靠且處理安全",
-          text: "可選遷移失敗後面板仍可恢復，異常或超大的 EPUB 壓縮檔也會受到明確限制。",
+          label: "不增加新模式",
+          text: "設定頁與現有 PDF/EPUB 側邊欄維持原有流程，無需切換額外模式。",
         },
       ],
       exampleLabel: "",
@@ -994,26 +994,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "ja-JP": {
       eyebrow: "更新のお知らせ",
-      title: "EPUB コンテキストチャットと安定したパネル起動",
-      lead: "AIdea は Zotero の EPUB リーダーパネルで書籍を文書コンテキストとして利用し、EPUB 2/3 構造からローカルで章のルーティングと範囲を制限した検索を行えるようになりました。",
-      note: "更新後に Zotero を再起動してください。PDF または EPUB を開き、同じ AIdea リーダーパネルをそのまま利用できます。追加のモード切り替えは不要です。",
+      title: "Zotero 10 への対応",
+      lead: "AIdea を Zotero 10.0.x にインストールして利用できるようになり、Zotero 7–9 のサポートも継続します。",
+      note: "更新後に Zotero を再起動してください。公式 XPI をインストールするか自動更新を使用でき、manifest.json を手動で変更する必要はありません。",
       alsoLabel: "今回の更新内容",
       alsoItems: [
         {
-          label: "EPUB サイドパネルチャット",
-          text: "Zotero の EPUB リーダーで特定の章や書籍全体について直接質問できます。",
+          label: "公式インストールと自動更新",
+          text: "公式 XPI と自動更新マニフェストが Zotero 10.0.x に対応しました。",
         },
         {
-          label: "ローカルで範囲を制限した検索",
-          text: "出版者構造、追質問の範囲、書籍全体のサンプリングをローカルで処理し、章の計画に追加のモデル呼び出しを行いません。",
+          label: "ライブラリ範囲の修正",
+          text: "Zotero 10 の複数ライブラリ選択 API により、個人、グループ、複数ライブラリの会話範囲を正しく保ちます。",
         },
         {
-          label: "コンテキスト付き選択翻訳",
-          text: "EPUB の選択範囲は、別のコールドスタート要求なしで範囲を制限した書籍コンテキストを直接利用します。",
+          label: "Zotero 7–9 のサポートを継続",
+          text: "旧バージョンの Zotero では既存のフォールバック API を引き続き使用します。",
         },
         {
-          label: "安定した起動と安全な処理",
-          text: "任意の移行に失敗してもパネルは回復でき、不正または過大な EPUB アーカイブには明確な制限が適用されます。",
+          label: "新しいモードは不要",
+          text: "設定画面と既存の PDF/EPUB サイドパネルは、追加モードなしで従来の操作を維持します。",
         },
       ],
       exampleLabel: "",
@@ -1023,26 +1023,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "ko-KR": {
       eyebrow: "업데이트 안내",
-      title: "EPUB 컨텍스트 채팅과 안정적인 패널 시작",
-      lead: "AIdea는 이제 Zotero EPUB 리더 패널에서 책을 문서 컨텍스트로 사용하고 EPUB 2/3 구조를 기반으로 로컬 장 라우팅과 제한된 검색을 수행합니다.",
-      note: "업데이트 후 Zotero를 다시 시작하세요. PDF 또는 EPUB를 열고 동일한 AIdea 리더 패널을 사용하면 되며 추가 모드 전환은 필요하지 않습니다.",
+      title: "Zotero 10 호환성",
+      lead: "이제 AIdea를 Zotero 10.0.x에 설치해 사용할 수 있으며 Zotero 7–9 지원도 계속 유지됩니다.",
+      note: "업데이트 후 Zotero를 다시 시작하세요. 공식 XPI를 설치하거나 자동 업데이트를 사용하면 되며 manifest.json을 직접 수정할 필요가 없습니다.",
       alsoLabel: "이번 업데이트 내용",
       alsoItems: [
         {
-          label: "EPUB 사이드 패널 채팅",
-          text: "Zotero EPUB 리더에서 특정 장이나 책 전체에 대해 직접 질문할 수 있습니다.",
+          label: "공식 설치 및 자동 업데이트",
+          text: "공식 XPI와 자동 업데이트 매니페스트가 이제 Zotero 10.0.x를 지원합니다.",
         },
         {
-          label: "로컬 제한 검색",
-          text: "출판 구조, 후속 질문 범위 및 책 전체 샘플링을 로컬에서 처리하며 장 계획을 위한 추가 모델 호출이 없습니다.",
+          label: "라이브러리 범위 수정",
+          text: "Zotero 10의 복수 라이브러리 선택 API로 개인, 그룹 및 다중 라이브러리 대화 범위를 올바르게 유지합니다.",
         },
         {
-          label: "컨텍스트 기반 선택 번역",
-          text: "EPUB 선택 영역은 별도의 콜드 스타트 요청 없이 제한된 책 컨텍스트를 바로 사용합니다.",
+          label: "Zotero 7–9 지원 유지",
+          text: "이전 Zotero 버전은 기존 대체 API를 계속 사용합니다.",
         },
         {
-          label: "안정적인 시작과 안전한 처리",
-          text: "선택적 마이그레이션이 실패해도 패널이 복구되며 비정상적이거나 지나치게 큰 EPUB 아카이브에는 명확한 제한이 적용됩니다.",
+          label: "새 모드 없음",
+          text: "설정과 기존 PDF/EPUB 사이드 패널은 추가 모드 없이 동일한 작업 흐름을 유지합니다.",
         },
       ],
       exampleLabel: "",
@@ -1052,26 +1052,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "fr-FR": {
       eyebrow: "Mise à jour",
-      title: "Chat contextuel EPUB et démarrage fiable du panneau",
-      lead: "AIdea peut désormais utiliser un livre EPUB comme contexte dans le panneau du lecteur Zotero, avec routage local des sections et recherche bornée à partir des structures EPUB 2/3.",
-      note: "Redémarrez Zotero après la mise à jour. Ouvrez un PDF ou un EPUB et utilisez le même panneau AIdea, sans changer de mode.",
+      title: "Compatibilité avec Zotero 10",
+      lead: "AIdea peut désormais être installé et utilisé avec Zotero 10.0.x, tout en conservant la prise en charge de Zotero 7–9.",
+      note: "Redémarrez Zotero après la mise à jour. Installez le XPI officiel ou utilisez la mise à jour automatique ; aucune modification manuelle de manifest.json n’est nécessaire.",
       alsoLabel: "Cette mise à jour comprend",
       alsoItems: [
         {
-          label: "Chat EPUB dans le panneau latéral",
-          text: "Interrogez directement un chapitre ou l'ensemble du livre dans le lecteur EPUB de Zotero.",
+          label: "Installation officielle et mises à jour",
+          text: "Le XPI officiel et le manifeste de mise à jour automatique acceptent maintenant Zotero 10.0.x.",
         },
         {
-          label: "Recherche locale bornée",
-          text: "La structure éditoriale, la portée des questions de suivi et l'échantillonnage du livre sont traités localement sans appel supplémentaire au modèle de planification.",
+          label: "Portée de bibliothèque corrigée",
+          text: "L’API plurielle de sélection des bibliothèques de Zotero 10 conserve la bonne portée pour les bibliothèques personnelles, de groupe et multiples.",
         },
         {
-          label: "Traduction de sélection contextualisée",
-          text: "Les sélections EPUB utilisent directement un contexte de livre borné, sans requête distincte de démarrage à froid.",
+          label: "Prise en charge de Zotero 7–9 conservée",
+          text: "Les anciennes versions de Zotero continuent d’utiliser l’API de repli existante.",
         },
         {
-          label: "Démarrage fiable et traitement sûr",
-          text: "Le panneau récupère après l'échec d'une migration facultative et les archives EPUB malformées ou surdimensionnées sont limitées.",
+          label: "Aucun nouveau mode",
+          text: "Les réglages et les panneaux latéraux PDF/EPUB existants conservent le même flux de travail sans mode supplémentaire.",
         },
       ],
       exampleLabel: "",
@@ -1081,26 +1081,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "de-DE": {
       eyebrow: "Update",
-      title: "EPUB-Kontextchat und zuverlässiger Panel-Start",
-      lead: "AIdea kann EPUB-Bücher jetzt im Zotero-Reader-Panel als Dokumentkontext verwenden und führt lokales Abschnittsrouting sowie begrenzte Suche anhand der EPUB-2/3-Struktur aus.",
-      note: "Starten Sie Zotero nach dem Update neu. Öffnen Sie eine PDF- oder EPUB-Datei und verwenden Sie dasselbe AIdea-Reader-Panel ohne zusätzlichen Moduswechsel.",
+      title: "Kompatibilität mit Zotero 10",
+      lead: "AIdea kann jetzt unter Zotero 10.0.x installiert und verwendet werden; Zotero 7–9 werden weiterhin unterstützt.",
+      note: "Starten Sie Zotero nach dem Update neu. Installieren Sie das offizielle XPI oder nutzen Sie das automatische Update; manifest.json muss nicht manuell geändert werden.",
       alsoLabel: "Dieses Update enthält",
       alsoItems: [
         {
-          label: "EPUB-Chat im Seitenbereich",
-          text: "Fragen Sie direkt im Zotero-EPUB-Reader nach Kapiteln oder dem gesamten Buch.",
+          label: "Offizielle Installation und Updates",
+          text: "Das offizielle XPI und das Manifest für automatische Updates unterstützen nun Zotero 10.0.x.",
         },
         {
-          label: "Lokale begrenzte Suche",
-          text: "Verlagsstruktur, Rückfragebereich und Buchstichproben werden lokal ohne zusätzlichen Planungsmodell-Aufruf verarbeitet.",
+          label: "Korrigierter Bibliotheksumfang",
+          text: "Die Mehrfachauswahl-API von Zotero 10 hält den Gesprächsumfang für persönliche, Gruppen- und mehrere Bibliotheken korrekt.",
         },
         {
-          label: "Kontextbezogene Auswahlübersetzung",
-          text: "EPUB-Auswahlen verwenden direkt begrenzten Buchkontext ohne separate Kaltstartanfrage.",
+          label: "Zotero 7–9 bleiben unterstützt",
+          text: "Ältere Zotero-Versionen verwenden weiterhin die bestehende Fallback-API.",
         },
         {
-          label: "Zuverlässiger Start und sichere Verarbeitung",
-          text: "Das Panel erholt sich von optionalen Migrationsfehlern; fehlerhafte oder übergroße EPUB-Archive werden begrenzt.",
+          label: "Keine neuen Modi",
+          text: "Einstellungen und die vorhandenen PDF/EPUB-Seitenbereiche behalten denselben Ablauf ohne zusätzlichen Modus.",
         },
       ],
       exampleLabel: "",
@@ -1110,26 +1110,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "es-ES": {
       eyebrow: "Actualización",
-      title: "Chat contextual EPUB e inicio fiable del panel",
-      lead: "AIdea ahora puede usar libros EPUB como contexto en el panel del lector de Zotero, con enrutamiento local de secciones y recuperación limitada desde estructuras EPUB 2/3.",
-      note: "Reinicia Zotero después de actualizar. Abre un PDF o EPUB y usa el mismo panel de AIdea, sin cambiar de modo.",
+      title: "Compatibilidad con Zotero 10",
+      lead: "AIdea ya se puede instalar y usar en Zotero 10.0.x, manteniendo la compatibilidad con Zotero 7–9.",
+      note: "Reinicia Zotero después de actualizar. Instala el XPI oficial o usa la actualización automática; no hace falta modificar manifest.json manualmente.",
       alsoLabel: "Esta actualización incluye",
       alsoItems: [
         {
-          label: "Chat EPUB en el panel lateral",
-          text: "Pregunta directamente por capítulos o por el libro completo en el lector EPUB de Zotero.",
+          label: "Instalación oficial y actualizaciones",
+          text: "El XPI oficial y el manifiesto de actualización automática ya admiten Zotero 10.0.x.",
         },
         {
-          label: "Recuperación local limitada",
-          text: "La estructura editorial, el alcance de preguntas posteriores y el muestreo del libro se procesan localmente sin otra llamada al modelo de planificación.",
+          label: "Ámbito de biblioteca corregido",
+          text: "La API plural de selección de bibliotecas de Zotero 10 mantiene el ámbito correcto para bibliotecas personales, de grupo y múltiples.",
         },
         {
-          label: "Traducción de selección con contexto",
-          text: "Las selecciones EPUB usan directamente contexto limitado del libro sin una solicitud separada de inicio en frío.",
+          label: "Se conserva Zotero 7–9",
+          text: "Las versiones anteriores de Zotero siguen usando la API alternativa existente.",
         },
         {
-          label: "Inicio fiable y procesamiento seguro",
-          text: "El panel se recupera de fallos de migración opcionales y los archivos EPUB dañados o demasiado grandes quedan limitados.",
+          label: "Sin modos nuevos",
+          text: "Los ajustes y los paneles laterales PDF/EPUB existentes conservan el mismo flujo sin un modo adicional.",
         },
       ],
       exampleLabel: "",
@@ -1139,26 +1139,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "ru-RU": {
       eyebrow: "Обновление",
-      title: "Контекстный чат EPUB и надёжный запуск панели",
-      lead: "AIdea теперь использует книги EPUB как контекст в панели ридера Zotero и выполняет локальную маршрутизацию разделов и ограниченный поиск по структуре EPUB 2/3.",
-      note: "После обновления перезапустите Zotero. Откройте PDF или EPUB и используйте ту же панель AIdea без переключения режима.",
+      title: "Совместимость с Zotero 10",
+      lead: "AIdea теперь можно установить и использовать в Zotero 10.0.x с сохранением поддержки Zotero 7–9.",
+      note: "После обновления перезапустите Zotero. Установите официальный XPI или используйте автообновление; вручную изменять manifest.json не нужно.",
       alsoLabel: "В это обновление входит",
       alsoItems: [
         {
-          label: "Чат EPUB в боковой панели",
-          text: "Задавайте вопросы о главе или всей книге прямо в EPUB-ридере Zotero.",
+          label: "Официальная установка и обновления",
+          text: "Официальный XPI и манифест автообновления теперь поддерживают Zotero 10.0.x.",
         },
         {
-          label: "Локальный ограниченный поиск",
-          text: "Структура издателя, область последующих вопросов и выборка по книге обрабатываются локально без дополнительного вызова модели планирования.",
+          label: "Исправленная область библиотеки",
+          text: "Множественный API выбора библиотек Zotero 10 сохраняет правильную область для личных, групповых и нескольких библиотек.",
         },
         {
-          label: "Перевод выделения с контекстом",
-          text: "Выделения EPUB сразу используют ограниченный контекст книги без отдельного запроса холодного запуска.",
+          label: "Поддержка Zotero 7–9 сохранена",
+          text: "Старые версии Zotero продолжают использовать существующий резервный API.",
         },
         {
-          label: "Надёжный запуск и безопасная обработка",
-          text: "Панель восстанавливается после сбоев необязательной миграции, а повреждённые или слишком большие архивы EPUB ограничиваются.",
+          label: "Без новых режимов",
+          text: "Настройки и существующие боковые панели PDF/EPUB работают как прежде, без дополнительного режима.",
         },
       ],
       exampleLabel: "",
@@ -1168,26 +1168,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "pt-BR": {
       eyebrow: "Atualização",
-      title: "Chat contextual EPUB e inicialização confiável do painel",
-      lead: "O AIdea agora usa livros EPUB como contexto no painel do leitor Zotero, com roteamento local de seções e recuperação limitada pelas estruturas EPUB 2/3.",
-      note: "Reinicie o Zotero após atualizar. Abra um PDF ou EPUB e use o mesmo painel AIdea, sem trocar de modo.",
+      title: "Compatibilidade com o Zotero 10",
+      lead: "O AIdea agora pode ser instalado e usado no Zotero 10.0.x, mantendo o suporte ao Zotero 7–9.",
+      note: "Reinicie o Zotero após atualizar. Instale o XPI oficial ou use a atualização automática; não é necessário editar manifest.json manualmente.",
       alsoLabel: "Esta atualização inclui",
       alsoItems: [
         {
-          label: "Chat EPUB no painel lateral",
-          text: "Pergunte diretamente sobre capítulos ou o livro inteiro no leitor EPUB do Zotero.",
+          label: "Instalação oficial e atualizações",
+          text: "O XPI oficial e o manifesto de atualização automática agora aceitam o Zotero 10.0.x.",
         },
         {
-          label: "Recuperação local limitada",
-          text: "A estrutura editorial, o escopo das perguntas seguintes e a amostragem do livro são tratados localmente sem chamada adicional ao modelo de planejamento.",
+          label: "Escopo correto da biblioteca",
+          text: "A API plural de seleção de bibliotecas do Zotero 10 mantém o escopo correto para bibliotecas pessoais, de grupo e múltiplas.",
         },
         {
-          label: "Tradução de seleção com contexto",
-          text: "Seleções EPUB usam diretamente contexto limitado do livro sem solicitação separada de inicialização a frio.",
+          label: "Suporte ao Zotero 7–9 mantido",
+          text: "Versões anteriores do Zotero continuam usando a API alternativa existente.",
         },
         {
-          label: "Inicialização confiável e processamento seguro",
-          text: "O painel se recupera de falhas de migração opcionais e arquivos EPUB malformados ou grandes demais são limitados.",
+          label: "Sem novos modos",
+          text: "As configurações e os painéis laterais PDF/EPUB existentes mantêm o mesmo fluxo sem um modo adicional.",
         },
       ],
       exampleLabel: "",
@@ -1197,26 +1197,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "ar-SA": {
       eyebrow: "تحديث",
-      title: "محادثة EPUB بالسياق وبدء موثوق للوحة",
-      lead: "يستطيع AIdea الآن استخدام كتب EPUB كسياق للمستند في لوحة قارئ Zotero، مع توجيه محلي للأقسام واسترجاع محدود من بنية EPUB 2/3.",
-      note: "أعد تشغيل Zotero بعد التحديث. افتح PDF أو EPUB واستخدم لوحة AIdea نفسها دون تبديل وضع إضافي.",
+      title: "التوافق مع Zotero 10",
+      lead: "يمكن الآن تثبيت AIdea واستخدامه على Zotero 10.0.x مع استمرار دعم Zotero 7–9.",
+      note: "أعد تشغيل Zotero بعد التحديث. ثبّت ملف XPI الرسمي أو استخدم التحديث التلقائي؛ لا حاجة إلى تعديل manifest.json يدويًا.",
       alsoLabel: "يتضمن هذا التحديث",
       alsoItems: [
         {
-          label: "محادثة EPUB في اللوحة الجانبية",
-          text: "اسأل عن فصل أو عن الكتاب كاملاً مباشرة في قارئ EPUB في Zotero.",
+          label: "التثبيت الرسمي والتحديثات",
+          text: "أصبح ملف XPI الرسمي وبيان التحديث التلقائي يدعمان Zotero 10.0.x.",
         },
         {
-          label: "استرجاع محلي محدود",
-          text: "تُعالج بنية الناشر ونطاق الأسئلة اللاحقة وأخذ عينات الكتاب محليًا دون استدعاء إضافي لنموذج التخطيط.",
+          label: "تصحيح نطاق المكتبة",
+          text: "تحافظ واجهة اختيار المكتبات المتعددة في Zotero 10 على النطاق الصحيح للمكتبات الشخصية والجماعية والمتعددة.",
         },
         {
-          label: "ترجمة تحديد مدعومة بالسياق",
-          text: "تستخدم تحديدات EPUB سياقًا محدودًا للكتاب مباشرة دون طلب بدء بارد منفصل.",
+          label: "استمرار دعم Zotero 7–9",
+          text: "تواصل إصدارات Zotero الأقدم استخدام واجهة الرجوع الحالية.",
         },
         {
-          label: "بدء موثوق ومعالجة آمنة",
-          text: "تتعافى اللوحة بعد فشل عمليات الترحيل الاختيارية وتُفرض حدود على أرشيفات EPUB التالفة أو الضخمة.",
+          label: "من دون أوضاع جديدة",
+          text: "تحافظ الإعدادات واللوحات الجانبية الحالية لـ PDF/EPUB على سير العمل نفسه دون وضع إضافي.",
         },
       ],
       exampleLabel: "",
@@ -1226,26 +1226,26 @@ export const CURRENT_UPDATE_NOTICE_COPIES: Record<PanelLang, UpdateNoticeCopy> =
     },
     "hi-IN": {
       eyebrow: "अपडेट",
-      title: "EPUB context chat और भरोसेमंद panel startup",
-      lead: "AIdea अब Zotero EPUB reader panel में पुस्तकों को document context की तरह उपयोग करता है और EPUB 2/3 structure से local section routing तथा bounded retrieval करता है।",
-      note: "अपडेट के बाद Zotero को पुनः शुरू करें। PDF या EPUB खोलें और बिना किसी अतिरिक्त mode switch के वही AIdea reader panel उपयोग करें।",
+      title: "Zotero 10 के साथ संगतता",
+      lead: "AIdea अब Zotero 10.0.x पर install और use किया जा सकता है, जबकि Zotero 7–9 support भी जारी है।",
+      note: "अपडेट के बाद Zotero को restart करें। Official XPI install करें या automatic update उपयोग करें; manifest.json को manually edit करने की जरूरत नहीं है।",
       alsoLabel: "इस अपडेट में शामिल है",
       alsoItems: [
         {
-          label: "EPUB side-panel chat",
-          text: "Zotero EPUB reader में किसी chapter या पूरी पुस्तक के बारे में सीधे पूछें।",
+          label: "Official installation और updates",
+          text: "Official XPI और automatic-update manifest अब Zotero 10.0.x को support करते हैं।",
         },
         {
-          label: "Local bounded retrieval",
-          text: "Publisher structure, follow-up scope और whole-book sampling local रूप से संभाले जाते हैं, planning model की अतिरिक्त call के बिना।",
+          label: "सही library scope",
+          text: "Zotero 10 का plural library-selection API personal, group और multi-library conversation scope सही रखता है।",
         },
         {
-          label: "Context-aware selection translation",
-          text: "EPUB selections अलग cold-start request के बिना bounded book context का सीधे उपयोग करते हैं।",
+          label: "Zotero 7–9 support जारी",
+          text: "पुराने Zotero versions मौजूदा fallback API का उपयोग जारी रखते हैं।",
         },
         {
-          label: "Reliable और safe",
-          text: "Optional migration failure के बाद panel recover कर सकता है और malformed या oversized EPUB archives पर स्पष्ट limits लागू होती हैं।",
+          label: "कोई नया mode नहीं",
+          text: "Settings और मौजूदा PDF/EPUB side panels बिना अतिरिक्त mode के वही workflow बनाए रखते हैं।",
         },
       ],
       exampleLabel: "",

--- a/test/librarySelection.test.ts
+++ b/test/librarySelection.test.ts
@@ -7,6 +7,7 @@ import {
   isManagedLibraryPanelSectionEnabled,
   resolveLibraryPanelDisplayState,
 } from "../src/modules/contextPanel/librarySelection";
+import { resolveActiveLibraryID } from "../src/modules/contextPanel/portalScope";
 
 describe("librarySelection", function () {
   it("classifies no selected items as empty", function () {
@@ -136,5 +137,87 @@ describe("librarySelection", function () {
     assert.isTrue(resolution.selectionChanged);
     assert.isFalse(resolution.manualStandaloneActive);
     assert.isTrue(resolution.displayState.standalonePanelVisible);
+  });
+
+  describe("active library scope", function () {
+    let originalZotero: unknown;
+    let pane: Record<string, unknown>;
+
+    beforeEach(function () {
+      originalZotero = (globalThis as Record<string, unknown>).Zotero;
+      pane = {};
+      (globalThis as Record<string, unknown>).Zotero = {
+        getActiveZoteroPane: () => pane,
+        Libraries: { userLibraryID: 1 },
+      };
+    });
+
+    afterEach(function () {
+      (globalThis as Record<string, unknown>).Zotero = originalZotero;
+    });
+
+    it("uses Zotero 10's plural API without calling the removed getter", function () {
+      pane.getSelectedLibraryIDs = () => [42];
+      let legacyCalled = false;
+      pane.getSelectedLibraryID = () => {
+        legacyCalled = true;
+        throw new Error("Use getSelectedLibraryIDs() instead");
+      };
+
+      assert.equal(resolveActiveLibraryID(), 42);
+      assert.isFalse(legacyCalled);
+    });
+
+    it("keeps the singular API fallback for Zotero 7 through 9", function () {
+      pane.getSelectedLibraryID = () => 42;
+      assert.equal(resolveActiveLibraryID(), 42);
+    });
+
+    it("normalizes and deduplicates selected library IDs", function () {
+      pane.getSelectedLibraryIDs = () => [null, 0, "42", 42, "invalid"];
+      assert.equal(resolveActiveLibraryID(), 42);
+    });
+
+    it("uses the selected items' library when several libraries are selected", function () {
+      pane.getSelectedLibraryIDs = () => [42, 84];
+      pane.getSelectedItems = () => [{ libraryID: 84 }, { libraryID: 84 }];
+      assert.equal(resolveActiveLibraryID(), 84);
+    });
+
+    it("does not pick an arbitrary library for items spanning libraries", function () {
+      pane.getSelectedLibraryIDs = () => [42, 84];
+      pane.getSelectedItems = () => [{ libraryID: 42 }, { libraryID: 84 }];
+      assert.equal(resolveActiveLibraryID(), 1);
+    });
+
+    it("uses the personal library for a multi-library selection without items", function () {
+      pane.getSelectedLibraryIDs = () => [42, 84];
+      assert.equal(resolveActiveLibraryID(), 1);
+    });
+
+    it("still checks selected items when the library getter throws", function () {
+      pane.getSelectedLibraryID = () => {
+        throw new Error("Library selection unavailable");
+      };
+      pane.getSelectedItems = () => [{ libraryID: 42 }];
+      assert.equal(resolveActiveLibraryID(), 42);
+    });
+
+    it("does not call the legacy getter when the plural selection is empty", function () {
+      pane.getSelectedLibraryIDs = () => [];
+      pane.getSelectedLibraryID = () => 84;
+      pane.getSelectedItems = () => [{ libraryID: 42 }];
+      assert.equal(resolveActiveLibraryID(), 42);
+    });
+
+    it("falls back safely when no selection can be read", function () {
+      pane.getSelectedLibraryIDs = () => {
+        throw new Error("Library selection unavailable");
+      };
+      pane.getSelectedItems = () => {
+        throw new Error("Item selection unavailable");
+      };
+      assert.equal(resolveActiveLibraryID(), 1);
+    });
   });
 });

--- a/test/pdfTranslator/processRunner.test.ts
+++ b/test/pdfTranslator/processRunner.test.ts
@@ -1,0 +1,117 @@
+import { assert } from "chai";
+
+describe("pdfTranslator process runner", function () {
+  let launchProcess: typeof import("../../src/modules/pdfTranslator/processRunner").launchProcess;
+  let processQueue: any[];
+  let originalComponents: unknown;
+  let originalServices: unknown;
+  let originalZotero: unknown;
+
+  before(async function () {
+    originalComponents = (globalThis as any).Components;
+    originalServices = (globalThis as any).Services;
+    originalZotero = (globalThis as any).Zotero;
+    processQueue = [];
+
+    (globalThis as any).Zotero = { isWin: true };
+    (globalThis as any).Services = {
+      dirsvc: {
+        get() {
+          return {
+            clone() {
+              return {
+                path: "C:\\Windows\\System32",
+                append(name: string) {
+                  this.path += `\\${name}`;
+                },
+                exists() {
+                  return true;
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    (globalThis as any).Components = {
+      interfaces: { nsIFile: {}, nsIProcess: {} },
+      classes: {
+        "@mozilla.org/file/local;1": {
+          createInstance() {
+            return {
+              path: "",
+              initWithPath(path: string) {
+                this.path = path;
+              },
+            };
+          },
+        },
+        "@mozilla.org/process/util;1": {
+          createInstance() {
+            const next = processQueue.shift();
+            if (!next) throw new Error("Missing mocked process");
+            return next;
+          },
+        },
+      },
+    };
+
+    ({ launchProcess } =
+      await import("../../src/modules/pdfTranslator/processRunner"));
+  });
+
+  after(function () {
+    (globalThis as any).Components = originalComponents;
+    (globalThis as any).Services = originalServices;
+    (globalThis as any).Zotero = originalZotero;
+  });
+
+  function createMainProcess(pid: number) {
+    return {
+      pid,
+      exitValue: 0,
+      directKillCount: 0,
+      init() {},
+      runAsync() {},
+      kill() {
+        this.directKillCount += 1;
+      },
+    };
+  }
+
+  it("uses taskkill /T /F for the bridge process tree on Windows", function () {
+    const main = createMainProcess(4321);
+    const treeKillCalls: string[][] = [];
+    const killer = {
+      exitValue: 0,
+      init() {},
+      run(_blocking: boolean, args: string[]) {
+        treeKillCalls.push(args);
+      },
+    };
+    processQueue.push(main, killer);
+
+    const running = launchProcess("C:\\Python\\python.exe", ["bridge.py"]);
+    running.kill();
+
+    assert.deepEqual(treeKillCalls, [["/PID", "4321", "/T", "/F"]]);
+    assert.equal(main.directKillCount, 0);
+  });
+
+  it("falls back to direct process kill when taskkill fails", function () {
+    const main = createMainProcess(9876);
+    const killer = {
+      exitValue: 1,
+      init() {},
+      run() {
+        throw new Error("taskkill unavailable");
+      },
+    };
+    processQueue.push(main, killer);
+
+    const running = launchProcess("C:\\Python\\python.exe", ["bridge.py"]);
+    running.kill();
+
+    assert.equal(main.directKillCount, 1);
+  });
+});

--- a/test/pdfTranslator/translationLifecycle.test.ts
+++ b/test/pdfTranslator/translationLifecycle.test.ts
@@ -1,0 +1,43 @@
+import { assert } from "chai";
+
+import { restartPausedTranslation } from "../../src/modules/pdfTranslator/translationLifecycle";
+
+describe("pdfTranslator pause/resume lifecycle", function () {
+  it("clears the paused controller and starts a fresh bridge", async function () {
+    const oldController = { id: "paused" };
+    const session = { isPaused: true, activeController: oldController };
+    let restartCount = 0;
+
+    restartPausedTranslation(
+      session,
+      async () => {
+        restartCount += 1;
+      },
+      () => assert.fail("restart should not fail"),
+    );
+    await Promise.resolve();
+
+    assert.isFalse(session.isPaused);
+    assert.isNull(session.activeController);
+    assert.equal(restartCount, 1);
+  });
+
+  it("reports a restart rejection to the UI error callback", async function () {
+    const session = { isPaused: true, activeController: {} };
+    let reported: unknown;
+
+    restartPausedTranslation(
+      session,
+      async () => {
+        throw new Error("restart failed");
+      },
+      (error) => {
+        reported = error;
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.instanceOf(reported, Error);
+    assert.equal((reported as Error).message, "restart failed");
+  });
+});

--- a/test/updateNotice.test.ts
+++ b/test/updateNotice.test.ts
@@ -10,8 +10,8 @@ import {
 } from "../src/modules/contextPanel/languages";
 
 describe("one-time update notice", function () {
-  it("uses the v3.4.0 notice id", function () {
-    assert.equal(NOTICE_ID, "v3.4.0-epub-context-chat-v1");
+  it("uses the v3.4.1 notice id", function () {
+    assert.equal(NOTICE_ID, "v3.4.1-zotero-10-compatibility-v1");
   });
 
   it("provides complete localized copy for every panel language", function () {
@@ -36,27 +36,33 @@ describe("one-time update notice", function () {
     }
   });
 
-  it("contains the approved EPUB scope without release-only attribution", function () {
+  it("contains the approved Zotero 10 scope without release-only attribution", function () {
     for (const { uiCode } of UI_LANGUAGE_OPTIONS) {
       const copy = CURRENT_UPDATE_NOTICE_COPIES[uiCode];
       const allCopy = JSON.stringify(copy);
-      assert.include(allCopy, "EPUB", `${uiCode}.epub`);
       assert.include(allCopy, "Zotero", `${uiCode}.zotero`);
-      assert.notMatch(allCopy, /@[A-Za-z0-9_-]+/, `${uiCode}.attribution`);
+      assert.include(allCopy, "10.0.x", `${uiCode}.zotero10`);
+      assert.include(allCopy, "PDF/EPUB", `${uiCode}.panels`);
+      assert.include(allCopy, "manifest.json", `${uiCode}.manifest`);
+      assert.notMatch(
+        allCopy,
+        /@[A-Za-z0-9_-]+|#77|Saywhatyousay|JorgeESantos/,
+        `${uiCode}.attribution`,
+      );
     }
 
     const english = JSON.stringify(CURRENT_UPDATE_NOTICE_COPIES["en-US"]);
-    assert.include(english, "EPUB side-panel chat");
-    assert.include(english, "Local bounded retrieval");
-    assert.include(english, "without an additional planning-model request");
-    assert.include(english, "without a separate cold-start request");
-    assert.include(english, "Panel initialization");
+    assert.include(english, "Zotero 10 compatibility");
+    assert.include(english, "Official installation and updates");
+    assert.include(english, "Correct library scope");
+    assert.include(english, "Zotero 7–9 retained");
+    assert.include(english, "No new modes");
 
     const chinese = JSON.stringify(CURRENT_UPDATE_NOTICE_COPIES["zh-CN"]);
-    assert.include(chinese, "EPUB 侧边栏对话");
-    assert.include(chinese, "本地有界检索");
-    assert.include(chinese, "不会额外调用模型规划章节");
-    assert.include(chinese, "不再执行单独的冷启动请求");
-    assert.include(chinese, "可选迁移失败后面板仍可恢复");
+    assert.include(chinese, "兼容 Zotero 10");
+    assert.include(chinese, "官方安装与自动更新兼容");
+    assert.include(chinese, "资料库范围修复");
+    assert.include(chinese, "保留 Zotero 7–9 支持");
+    assert.include(chinese, "不增加新模式");
   });
 });


### PR DESCRIPTION
## Summary

- Extend the packaged XPI and generated update manifest to Zotero 10.0.x, retaining the existing minimum version.
- Prefer `getSelectedLibraryIDs()` on Zotero 10. Preserve the legacy API for Zotero 7–9, and continue checking selected items if a library getter throws.
- Resolve group-library scope correctly and avoid choosing an arbitrary library for selections spanning libraries.
- Prepare version 3.4.1 and bilingual release notes in the existing release format.

Addresses #77. Keep the issue open until the release and updater assets have been published and verified.

## Verification

- 447 unit tests passed. The new regression cases produced 5 failures against the original implementation before the fix.
- `npm run build`, `npm run lint:check`, and `git diff --check` passed.
- Verified XPI ZIP integrity, embedded version and compatibility range, and the updater SHA-512 hash.
- In a separate local Windows Zotero 10.0.1 profile, the native AddonManager rejected 3.4.0 as incompatible and accepted and installed the actual 3.4.1 XPI with compatibility checking enabled.
- Verified startup, restart, disable/re-enable cleanup, settings controls, group and multi-library selections, and PDF/EPUB reader panels. No requests were sent to model providers during these smoke tests.

## Release status

The existing tag-triggered release workflow is unchanged. Publication of `v3.4.1` is pending final maintainer verification.